### PR TITLE
removed the plant-generic entry

### DIFF
--- a/nfdapi/nfdcore/initmodel.py
+++ b/nfdapi/nfdcore/initmodel.py
@@ -48,7 +48,6 @@ occurrence_cat_dict = {
 occurrence_subcat = [('co', _('Conifer'), 'plant'),
                      ('fe', _('Fern'), 'plant'),
                      ('fl', _('Flowering plant'), 'plant'),
-                     ('pl', _('Plant - generic'), 'plant'), # for other kind of plants such as non-conifer trees
                      ('mo', _('Moss'), 'plant'),
                      ('fu', _('Fungus'), 'fungus'),
                      ('sl', _('Slime mold'), 'slimemold', ),

--- a/nfdapi/nfdcore/nfdserializers.py
+++ b/nfdapi/nfdcore/nfdserializers.py
@@ -107,10 +107,6 @@ def get_sub_category_detail(subcategory_code, parameter_name):
             "serializer": NaturalAreaElementSerializer,
             "form_definitions": formdefinitions.NATURAL_AREA,
         },
-        "pl": {  # FIXME
-            "serializer": serializers.Serializer,
-            "form_definitions": None,
-        },
         "sl": {
             "serializer": SlimeMoldDetailsSerializer,
             "form_definitions": formdefinitions.SLIMEMOLD,
@@ -232,7 +228,10 @@ def get_serializer_fields(form_name, model):
 
 
 def init_forms(category_code):
-    forms = get_sub_category_detail(category_code, "form_definitions")
+    try:
+        forms = get_sub_category_detail(category_code, "form_definitions")
+    except KeyError:
+        raise RuntimeError("Invalid category: {!r}".format(category_code))
     forms_dict = formdefinitions.get_form_dict(forms)
     return forms, forms_dict
 

--- a/nfdapi/nfdcore/views.py
+++ b/nfdapi/nfdcore/views.py
@@ -667,17 +667,24 @@ def get_feature_type(request, occurrence_subcat, feature_id=None):
             feat = OccurrenceNaturalArea.objects.get(pk=feature_id)
         else:
             feat = OccurrenceTaxon.objects.get(pk=feature_id)
-        ftdata = nfdserializers.serialize_feature_types(feat.occurrence_cat)
+        try:
+            result = nfdserializers.serialize_feature_types(
+                feat.occurrence_cat)
+        except RuntimeError as exc:
+            result = {"error": str(exc)}
     else:  # get category code instead of the main category
         occurrence_cat = OccurrenceCategory.objects.get(code=occurrence_subcat)
         is_writer, is_publisher = get_permissions(
             request.user, occurrence_cat.main_cat)
-        ftdata = nfdserializers.serialize_feature_types(
-            occurrence_cat,
-            is_writer=is_writer,
-            is_publisher=is_publisher
-        )
-    return Response(ftdata)
+        try:
+            result = nfdserializers.serialize_feature_types(
+                occurrence_cat,
+                is_writer=is_writer,
+                is_publisher=is_publisher
+            )
+        except RuntimeError as exc:
+            result = {"error": str(exc)}
+    return Response(result)
 
 
 class SpeciesPaginationClass(PageNumberPagination):


### PR DESCRIPTION
This PR is connected to #119 - it implements the changes required on the backend.

Removes the `plant-generic` category:
- removed it from the initial model data;
- removed from the form definitions too;
- made the featuretypes view a bit more robust;

Additional changes are required on the frontend for the mentioned issue to be closed.