### PR TITLE
added textarea as a type for the notes

### DIFF
--- a/nfdapi/nfdcore/nfdserializers.py
+++ b/nfdapi/nfdcore/nfdserializers.py
@@ -294,7 +294,7 @@ def _get_form_items(name, model, is_writer, is_publisher):
     form_items.append({
         "mandatory": False,
         "readonly": False,
-        "type": "string",
+        "type": "textarea",
         "key": "notes.note.{}".format(name.split(".")[-1]),
         "label": "notes"
     })


### PR DESCRIPTION
This PR is connected to #116 

It modifies the type of the notes to be `textarea`. This should allow the frontend to render the notes on a more suitable UI widget. 