### PR TITLE
fixed duplicate form fields for notes on management tab

### DIFF
--- a/nfdapi/nfdcore/nfdserializers.py
+++ b/nfdapi/nfdcore/nfdserializers.py
@@ -285,9 +285,9 @@ def _get_form_items(name, model, is_writer, is_publisher):
         )
     elif name == formdefinitions.MANAGEMENT_FORM_NAME:
         if is_publisher:
-            form_items = formdefinitions.MANAGEMENT_FORM_ITEMS_PUBLISHER
+            form_items = list(formdefinitions.MANAGEMENT_FORM_ITEMS_PUBLISHER)
         else:
-            form_items = formdefinitions.MANAGEMENT_FORM_ITEMS
+            form_items = list(formdefinitions.MANAGEMENT_FORM_ITEMS)
     else:
         form_items = _get_form_featuretype(
             name, model, is_writer, is_publisher)


### PR DESCRIPTION
This PR relates to #116 

It is a fix for an issue reported by @kappu72 via skype, where the backend was sending incorrect form definitions for the _Management_ tab regarding the `notes` field.

The symptom was that the backend would send an increasing number of `notes` fields on the _Management_ tab's definition. The number would increase with each request.

The fix was to make sure a fresh copy of the form definition is processed on each request/response cycle.