### PR TITLE
changed name of the observation tab

### DIFF
--- a/nfdapi/nfdcore/formdefinitions.py
+++ b/nfdapi/nfdcore/formdefinitions.py
@@ -119,7 +119,7 @@ LAND_ANIMAL = [
             'observation.recorder'
         ]
     ),
-    ('observation.reporter', models.PointOfContact, []),
+    ('Observer', models.PointOfContact, []),
     ('observation.verifier', models.PointOfContact, []),
     ('observation.recorder', models.PointOfContact, []),
     ('voucher', models.Voucher, []),


### PR DESCRIPTION
This PR is connected to #122 
It renames the form definition for the observation's reporter to _Observer_

There is a remaining task to be done for this which is adjusting the icon. That must be done on the frontend part of the code and has been reported to @kappu72 