### PR TITLE
fixed incorrect form definition

### DIFF
--- a/nfdapi/nfdcore/models.py
+++ b/nfdapi/nfdcore/models.py
@@ -32,7 +32,7 @@ PHOTO_THUMB_SIZE=300
 FILENAME_MAX_LENGTH=2048
 
 
-def get_jsonfield_validation_choices(model, field_name):
+def get_jsonfield_validation_choices(model, field_name, include_values=False):
     """Return the set of legal values for a given JSONField
 
     In this project we are using JSONField to store arrays of values in order
@@ -48,6 +48,8 @@ def get_jsonfield_validation_choices(model, field_name):
         The model where the JSONField is defined
     field_name: str
         Name of the JSONField on the model
+    include_values: bool, optional
+        Whether or not to include both the code and the name for each choice
 
     """
 
@@ -127,8 +129,12 @@ def get_jsonfield_validation_choices(model, field_name):
         lookup_name = ".".join((model_class.__name__.lower(), field_name))
         dictionary_table_model = jsonfield_mapping.get(lookup_name)
         try:
-            choices = dictionary_table_model.objects.values_list(
-                "code", flat=True)
+            if include_values:
+                choices = dictionary_table_model.objects.values_list(
+                    "code", "name")
+            else:
+                choices = dictionary_table_model.objects.values_list(
+                    "code", flat=True)
         except AttributeError:
             choices = None
         if choices is not None:

--- a/nfdapi/nfdcore/nfdserializers.py
+++ b/nfdapi/nfdcore/nfdserializers.py
@@ -323,12 +323,7 @@ def _get_form_featuretype(form_name, model, is_writer, is_publisher,
         if type_ == "stringcombo" :
             fdef["values"] = {"items": _get_related_items(f)}
         elif type_ == "stringcombo_multiple":
-            fdef["values"] = {
-                "items": models.get_jsonfield_validation_choices(
-                    model=model,
-                    field_name=f.name
-                )
-            }
+            fdef["values"] = {"items": _get_jsonfield_items(model, f)}
         mfield = model_fields.get(f.name)
         if mfield:
             fdef['readonly'] = getattr(mfield, "read_only", False)
@@ -354,6 +349,19 @@ def _get_related_items(field):
             "key": instance.code,
             "value": instance.name,
         })
+    return result
+
+
+def _get_jsonfield_items(model, field):
+    choices = models.get_jsonfield_validation_choices(model, field.name,
+                                                      include_values=True)
+    result = []
+    if choices is not None:
+        for code, name in choices:
+            result.append({
+                "key": code,
+                "value": name
+            })
     return result
 
 


### PR DESCRIPTION
This PR is connected to #115 

It fixes an incorrect serialization of the featuretype forms when there are multiple values. In order to comply with the expectations of the frontend, the response is now

```json
{
  "values": {
    "items": [
      {
        "value": "dried egg shell",
        "key": "1"
      },
      {
        "value": "dried/pressed/mounted",
        "key": "2"
      },
      {
        "value": "dried skeletal element",
        "key": "3"
      },
      {
        "value": "dried skeleton",
        "key": "4"
      },
      {
        "value": "dried skin",
        "key": "5"
      },
      {
        "value": "frozen",
        "key": "6"
      },
      {
        "value": "vial",
        "key": "7"
      },
      {
        "value": "N/A",
        "key": "8"
      }
    ]
  },
  "mandatory": false,
  "type": "stringcombo_multiple",
  "key": "voucher.storage",
  "label": "storage"
},
```