### PR TITLE
fixed bug with the rename of the observer tab

### DIFF
--- a/nfdapi/nfdcore/formdefinitions.py
+++ b/nfdapi/nfdcore/formdefinitions.py
@@ -114,7 +114,7 @@ LAND_ANIMAL = [
         'observation',
         models.OccurrenceObservation,
         [
-            'observation.reporter',
+            'Observer',
             'observation.verifier',
             'observation.recorder'
         ]


### PR DESCRIPTION
This PR is connected to #122 

It fixes a bug with the renaming of the `Observer` tab where it would not be possible to retrieve the correct form definitions anymore.

The rename of the tab had to also be reflected in the place where it appeared as a child of some other form definitions