### PR TITLE
moved form fields around and fixed stringcombo issue

### DIFF
--- a/nfdapi/nfdcore/form_definitions/common-pages.yml
+++ b/nfdapi/nfdcore/form_definitions/common-pages.yml
@@ -136,20 +136,17 @@ observation:
     - label: Observation date
       field: observation.observation_date
       widget: date
-    - label: Recording datetime
-      field: observation.recording_datetime
-      widget: datetime
     - label: Daytime
       field: observation.daytime
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.DayTime
     - label: Season
       field: observation.season
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.Season
     - label: Record origin
       field: observation.record_origin
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.RecordOrigin
     - label: Notes
       field: notes.note.observation
@@ -208,6 +205,12 @@ recorder:
       field: observation.recorder.email
     - label: Street address
       field: observation.recorder.street_address
+    - label: Recording datetime
+      field: observation.recording_datetime
+      widget: date
+    - label: Recording station
+      field: observation.recording_station
+      widget: textarea
     - label: Notes
       field: notes.note.recorder
       widget: textarea
@@ -228,11 +231,11 @@ voucher:
       widget: boolean
     - label: Preservative
       field: voucher.preservative
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Preservative
     - label: Storage
       field: voucher.storage
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Storage
     - label: Repository
       field: voucher.repository
@@ -314,11 +317,11 @@ location:
       field: location.site_description
     - label: reservation
       field: location.reservation
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Reservation
     - label: watershed
       field: location.watershed
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Watershed
     - label: directions
       field: location.directions

--- a/nfdapi/nfdcore/form_definitions/conifer-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/conifer-plant-forms.yml
@@ -31,39 +31,39 @@
   fields:
     - label: plant count
       field: details.plant_count
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime
       field: details.moisture_regime
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.MoistureRegime
     - label: ground surface
       field: details.ground_surface
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GroundSurface
     - label: tree canopy cover
       field: details.tree_canopy_cover
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.CanopyCover
     - label: general habitat category
       field: details.general_habitat_category
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GeneralHabitatCategory
     - label: leap landcover category
       field: details.leap_land_cover_category
     - label: landscape position
       field: details.landscape_position
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LandscapePosition
     - label: aspect
       field: details.aspect
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Aspect
     - label: slope
       field: details.slope
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Slope
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/form_definitions/fern-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/fern-plant-forms.yml
@@ -31,43 +31,43 @@
   fields:
     - label: plant count
       field: details.plant_count
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime
       field: details.moisture_regime
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.MoistureRegime
     - label: ground surface
       field: details.ground_surface
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GroundSurface
     - label: tree canopy cover
       field: details.tree_canopy_cover
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.CanopyCover
     - label: general habitat category
       field: details.general_habitat_category
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GeneralHabitatCategory
     - label: leap landcover category
       field: details.leap_land_cover_category
     - label: landscape position
       field: details.landscape_position
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LandscapePosition
     - label: aspect
       field: details.aspect
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Aspect
     - label: slope
       field: details.slope
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Slope
     - label: lifestages
       field: details.lifestages
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FernLifestages
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/form_definitions/flowering-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/flowering-plant-forms.yml
@@ -31,43 +31,43 @@
   fields:
     - label: plant count
       field: details.plant_count
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime
       field: details.moisture_regime
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.MoistureRegime
     - label: ground surface
       field: details.ground_surface
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GroundSurface
     - label: tree canopy cover
       field: details.tree_canopy_cover
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.CanopyCover
     - label: general habitat category
       field: details.general_habitat_category
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GeneralHabitatCategory
     - label: leap landcover category
       field: details.leap_land_cover_category
     - label: landscape position
       field: details.landscape_position
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LandscapePosition
     - label: aspect
       field: details.aspect
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Aspect
     - label: slope
       field: details.slope
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Slope
     - label: lifestages
       field: details.lifestages
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FernLifestages
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/form_definitions/fungus-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/fungus-forms.yml
@@ -38,35 +38,35 @@
       field: details.mycelium_description
     - label: canopy cover
       field: details.canopy_cover
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.CanopyCover
     - label: aspect
       field: details.aspect
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Aspect
     - label: slope
       field: details.slope
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Slope
     - label: landscape position
       field: details.landscape_position
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LandscapePosition
     - label: apparent substrate
       field: details.apparent_substrate
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungusApparentSubstrate
     - label: mushroom vertical location
       field: details.mushroom_vertical_location
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.MushroomVerticalLocation
     - label: mushroom growth form
       field: details.mushroom_growth_form
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.MushroomGrowthForm
     - label: mushroom odor
       field: details.mushroom_odor
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.MushroomOdor
     - label: Notes
       field: notes.note.details
@@ -85,59 +85,59 @@
   fields:
     - label: gnat association
       field: details.other_observed_associations.gnat_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: ants association
       field: details.other_observed_associations.ants_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: termite association
       field: details.other_observed_associations.termite_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: beetles association
       field: details.other_observed_associations.beetles_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: snow flea association
       field: details.other_observed_associations.snow_flea_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: slug association
       field: details.other_observed_associations.slug_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: snail association
       field: details.other_observed_associations.snail_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: skunk association
       field: details.other_observed_associations.skunk_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: badger association
       field: details.other_observed_associations.badger_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: easter gray squirrel association
       field: details.other_observed_associations.easter_gray_squirrel_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: chipmunk association
       field: details.other_observed_associations.chipmunk_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: other small rodent association
       field: details.other_observed_associations.other_small_rodent_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: turtle association
       field: details.other_observed_associations.turtle_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: deer association
       field: details.other_observed_associations.deer_association
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FungalAssociationType
     - label: Notes
       field: notes.note.other_observed_association

--- a/nfdapi/nfdcore/form_definitions/land-animal-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/land-animal-forms.yml
@@ -19,14 +19,14 @@
 #   - datetime
 #   - integer
 #   - double
-#   - select
-#   - select_multiple
+#   - stringcombo
+#   - stringcombo_multiple
 #
 # - readonly - optional (defaults to false). Whether the frontend should allow
 #   editing this field's value
 #
 # - choices - optional (defaults to null). This should be used together with
-#   widget of type `select` or `select_multiple` and it should be the name of
+#   widget of type `stringcombo` or `stringcombo_multiple` and it should be the name of
 #   a models.DictionaryTable subclass
 #
 # - show_key_with_value - optional (defaults to false)
@@ -65,23 +65,23 @@
   fields:
     - label: Gender
       field: details.gender
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Gender
     - label: Marks
       field: details.marks
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Marks
     - label: Diseases and abnormalities
       field: details.diseases_and_abnormalities
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.DiseasesAndAbnormalities
     - label: Sampler
       field: details.sampler
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.TerrestrialSampler
     - label: Stratum
       field: details.stratum
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.TerrestrialStratum
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/form_definitions/moss-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/moss-forms.yml
@@ -31,43 +31,43 @@
   fields:
     - label: plant count
       field: details.plant_count
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime
       field: details.moisture_regime
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.MoistureRegime
     - label: ground surface
       field: details.ground_surface
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GroundSurface
     - label: tree canopy cover
       field: details.tree_canopy_cover
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.CanopyCover
     - label: general habitat category
       field: details.general_habitat_category
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GeneralHabitatCategory
     - label: leap landcover category
       field: details.leap_land_cover_category
     - label: landscape position
       field: details.landscape_position
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LandscapePosition
     - label: aspect
       field: details.aspect
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Aspect
     - label: slope
       field: details.slope
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Slope
     - label: lifestages
       field: details.lifestages
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.FernLifestages
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/form_definitions/natural-area-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/natural-area-forms.yml
@@ -3,19 +3,19 @@
   fields:
     - label: CM status
       field: element.cm_status
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.CmStatus
     - label: S rank
       field: element.s_rank
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.SRank
     - label: N rank
       field: element.n_rank
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.NRank
     - label: G rank
       field: element.g_rank
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.GRank
     - label: natural area code
       field: element.natural_area_code_nac
@@ -24,7 +24,7 @@
       widget: textarea
     - label: element type
       field: element.type
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.NaturalAreaType
     - label: notable features
       field: element.notable_features
@@ -33,43 +33,43 @@
       widget: double
     - label: aspect
       field: element.aspect
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Aspect
     - label: slope
       field: element.slope
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Slope
     - label: sensitivity
       field: element.sensitivity
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.CMSensitivity
     - label: condition
       field: element.condition
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.NaturalAreaCondition
     - label: leap landcover category
       field: element.leap_land_cover_category
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LeapLandCover
     - label: landscape position
       field: element.landscape_position
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LandscapePosition
     - label: glaciar diposit
       field: element.glaciar_diposit
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GlacialDeposit
     - label: pleistocene glaciar diposit
       field: element.pleistocene_glaciar_diposit
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.GlacialDepositPleistoceneAge
     - label: bedrock and outcrops
       field: element.bedrock_and_outcrops
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.BedrockAndOutcrops
     - label: regional frequency
       field: element.regional_frequency
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.RegionalFrequency
     - label: Notes
       field: notes.note.element

--- a/nfdapi/nfdcore/form_definitions/pond-lake-animal-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/pond-lake-animal-forms.yml
@@ -31,19 +31,19 @@
   fields:
     - label: Gender
       field: details.gender
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Gender
     - label: Marks
       field: details.marks
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Marks
     - label: Diseases and abnormalities
       field: details.diseases_and_abnormalities
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.DiseasesAndAbnormalities
     - label: sampler
       field: details.sampler
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.AquaticSampler
     - label: lentic size approx (acres)
       field: details.lentic_size_acres_aprox
@@ -61,19 +61,19 @@
       field: details.pond_lake_name
     - label: pond lake type
       field: details.pond_lake_type
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.PondLakeType
     - label: pond lake use
       field: details.pond_lake_use
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.PondLakeUse
     - label: shoreline type
       field: details.shoreline_type
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.ShorelineType
     - label: microhabitat
       field: details.microhabitat
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LakeMicrohabitat
     - label: microhabitat comments
       field: details.microhabitat_comments

--- a/nfdapi/nfdcore/form_definitions/slimemold-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/slimemold-forms.yml
@@ -31,11 +31,11 @@
   fields:
     - label: slime mold class
       field: details.slime_mold_class
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.SlimeMoldClass
     - label: slime mold media
       field: details.slime_mold_media
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.SlimeMoldMedia
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/form_definitions/stream-animal-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/stream-animal-forms.yml
@@ -31,19 +31,19 @@
   fields:
     - label: Gender
       field: details.gender
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Gender
     - label: Marks
       field: details.marks
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Marks
     - label: Diseases and abnormalities
       field: details.diseases_and_abnormalities
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.DiseasesAndAbnormalities
     - label: sampler
       field: details.sampler
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.AquaticSampler
     - label: stream name 1
       field: details.stream_name_1
@@ -53,23 +53,23 @@
       field: details.pemso_code
     - label: designated use
       field: details.designated_use
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.StreamDesignatedUse
     - label: channel type
       field: details.channel_type
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.ChannelType
     - label: HMFEI local abundance
       field: details.hmfei_local_abundance
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.HmfeiLocalAbundance
     - label: lotic habitat type
       field: details.lotic_habitat_type
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.LoticHabitatType
     - label: water flow type
       field: details.water_flow_type
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.WaterFlowType
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/form_definitions/wetland-animal-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/wetland-animal-forms.yml
@@ -31,19 +31,19 @@
   fields:
     - label: Gender
       field: details.gender
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Gender
     - label: Marks
       field: details.marks
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.Marks
     - label: Diseases and abnormalities
       field: details.diseases_and_abnormalities
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.DiseasesAndAbnormalities
     - label: sampler
       field: details.sampler
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.AquaticSampler
     - label: lentic size approx (acres)
       field: details.lentic_size_acres_aprox
@@ -61,26 +61,26 @@
       field: details.wetland_name
     - label: wetland type
       field: details.wetland_type
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.WetlandType
     - label: active management
       field: details.active_management
       widget: boolean
     - label: wetland location
       field: details.wetland_location
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.WetlandLocation
     - label: connectivity
       field: details.connectivity
-      widget: select
+      widget: stringcombo
       choices: nfdcore.models.WetlandConnectivity
     - label: water source
       field: details.water_source
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.WaterSource
     - label: habitat feature
       field: details.habitat_feature
-      widget: select_multiple
+      widget: stringcombo_multiple
       choices: nfdcore.models.WetlandHabitatFeature
     - label: Notes
       field: notes.note.details

--- a/nfdapi/nfdcore/nfdserializers.py
+++ b/nfdapi/nfdcore/nfdserializers.py
@@ -1750,7 +1750,7 @@ def get_field_representation(field_definition):
         "mandatory": field_definition.get("mandatory", False),
         "readonly": field_definition.get("readonly", False),
     }
-    if field["type"] in ("select", "select_multiple"):
+    if field["type"] in ("stringcombo", "stringcombo_multiple"):
         choices_dict_model_path = field_definition.get("choices")
         field["values"] = {"items": []}
         if choices_dict_model_path is not None:


### PR DESCRIPTION
This PR closes #123 and is connected to #177 
The `recording_datetime` and `recording_station` fields have been moved from the `Observation` form definition to `Observation.recorder`

It also fixes an issue with the _types_ of fields in the form definitions being incorrectly defined as `select` and `select_multiple`, where the terms expected by the frontend are `stringcombo` and `stringcombo_multiple` respectively