### PR TITLE
Added watershed as an additional filter parameter

### DIFF
--- a/nfdapi/nfdcore/views.py
+++ b/nfdapi/nfdcore/views.py
@@ -544,6 +544,10 @@ class TaxonFilter(FilterSet):
         name="location__reservation",
         lookup_expr="icontains",
     )
+    watershed = django_filters.filters.CharFilter(
+        name="location__watershed",
+        lookup_expr="icontains",
+    )
     cm_status = django_filters.filters.ModelChoiceFilter(
         name="taxon__cm_status__code",
         queryset=models.CmStatus.objects.all()


### PR DESCRIPTION
This PR is connected to #139 
It adds `watershed` as an additional filtering parameter to all featuretypes except naturalarea. It can be used like this:

```
/layers/animal/?watershed=2
```

As show in the example, the frontend is expected to send back the relevant `models.Watershed.code` attribute