### PR TITLE
added the lifestages tab and fixed issues uncovered during testing

### DIFF
--- a/nfdapi/nfdcore/form_definitions/common-pages.yml
+++ b/nfdapi/nfdcore/form_definitions/common-pages.yml
@@ -516,7 +516,7 @@ voucher:
 animal_lifestages:
   fields:
     - label: lifestages
-      field: lifestages
+      field: details.lifestages
       widget: stringcombo_multiple
       choices: nfdcore.models.AnimalLifestages
 

--- a/nfdapi/nfdcore/form_definitions/conifer-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/conifer-plant-forms.yml
@@ -72,27 +72,14 @@
 - id: details.lifestages
   label: Lifestages
   fields:
-    - label: vegetative
-      field: details.lifestages.vegetative
-      widget: double
-    - label: immature ovulate cones
-      field: details.lifestages.immature_ovulate_cones
-      widget: double
-    - label: mature ovulate cones
-      field: details.lifestages.mature_ovulate_cones
-      widget: double
-    - label: spent ovulate cones
-      field: details.lifestages.spent_ovulate_cones
-      widget: double
-    - label: immature pollen cones
-      field: details.lifestages.immature_pollen_cones
-      widget: double
-    - label: mature pollen cones
-      field: details.lifestages.mature_pollen_cones
-      widget: double
-    - label: spent pollen cones
-      field: details.lifestages.spent_pollen_cones
-      widget: double
+    - label: lifecycle
+      field: details.lifestages
+      widget: stringcombo_multiple
+      choices: nfdcore.models.ConiferLifestages
+    - label: plant count
+      field: details.plant_count
+      widget: stringcombo
+      choices: nfdcore.models.PlantCount
     - label: Notes
       field: notes.note.lifestages
       widget: textarea

--- a/nfdapi/nfdcore/form_definitions/fern-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/fern-plant-forms.yml
@@ -65,12 +65,23 @@
       field: details.slope
       widget: stringcombo_multiple
       choices: nfdcore.models.Slope
-    - label: lifestages
+    - label: Notes
+      field: notes.note.details
+      widget: textarea
+
+- id: details.lifestages
+  label: Lifestages
+  fields:
+    - label: lifecycle
       field: details.lifestages
       widget: stringcombo_multiple
       choices: nfdcore.models.FernLifestages
+    - label: plant count
+      field: details.plant_count
+      widget: stringcombo
+      choices: nfdcore.models.PlantCount
     - label: Notes
-      field: notes.note.details
+      field: notes.note.lifestages
       widget: textarea
 
 - id: details.disturbance_type

--- a/nfdapi/nfdcore/form_definitions/flowering-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/flowering-plant-forms.yml
@@ -29,10 +29,6 @@
 - id: details
   label: Details
   fields:
-    - label: plant count
-      field: details.plant_count
-      widget: stringcombo
-      choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime
@@ -65,12 +61,23 @@
       field: details.slope
       widget: stringcombo_multiple
       choices: nfdcore.models.Slope
-    - label: lifestages
-      field: details.lifestages
-      widget: stringcombo_multiple
-      choices: nfdcore.models.FernLifestages
     - label: Notes
       field: notes.note.details
+      widget: textarea
+
+- id: details.lifestages
+  label: Lifestages
+  fields:
+    - label: lifecycle
+      field: details.lifestages
+      widget: stringcombo_multiple
+      choices: nfdcore.models.FloweringPlantLifestages
+    - label: plant count
+      field: details.plant_count
+      widget: stringcombo
+      choices: nfdcore.models.PlantCount
+    - label: Notes
+      field: notes.note.lifestages
       widget: textarea
 
 - id: details.disturbance_type

--- a/nfdapi/nfdcore/form_definitions/moss-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/moss-plant-forms.yml
@@ -65,12 +65,23 @@
       field: details.slope
       widget: stringcombo_multiple
       choices: nfdcore.models.Slope
-    - label: lifestages
-      field: details.lifestages
-      widget: stringcombo_multiple
-      choices: nfdcore.models.FernLifestages
     - label: Notes
       field: notes.note.details
+      widget: textarea
+
+- id: details.lifestages
+  label: Lifestages
+  fields:
+    - label: lifecycle
+      field: details.lifestages
+      widget: stringcombo_multiple
+      choices: nfdcore.models.MossLifestages
+    - label: plant count
+      field: details.plant_count
+      widget: stringcombo
+      choices: nfdcore.models.PlantCount
+    - label: Notes
+      field: notes.note.lifestages
       widget: textarea
 
 - id: details.disturbance_type

--- a/nfdapi/nfdcore/nfdserializers.py
+++ b/nfdapi/nfdcore/nfdserializers.py
@@ -134,9 +134,9 @@ def delete_object_and_children(parent_instance):
     children = []
 
     if not getattr(parent_instance, '_meta', None):
-        print parent_instance
-        print type(parent_instance)
-        print repr(parent_instance)
+        print(parent_instance)
+        print(type(parent_instance))
+        print(repr(parent_instance))
     if not isinstance(parent_instance, QuerySet):
         for f in parent_instance._meta.get_fields():
             if is_deletable_field(f):
@@ -463,13 +463,6 @@ class OccurrenceObservationSerializer(CustomModelSerializerMixin,
         exclude = ('id',)
 
 
-class AnimalLifestagesSerializer(CustomModelSerializerMixin,
-                                 serializers.ModelSerializer):
-    class Meta:
-        model = models.AnimalLifestages
-        exclude = ('id',)
-
-
 class BaseDetailsSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
@@ -480,7 +473,6 @@ class BaseDetailsSerializer(serializers.ModelSerializer):
 
 
 class LandAnimalDetailsSerializer(CustomModelSerializerMixin, BaseDetailsSerializer):
-    lifestages = AnimalLifestagesSerializer(required=False)
 
     def validate_marks(self, value):
         return validate_json_field(value, models.AnimalDetails, "marks")
@@ -491,6 +483,9 @@ class LandAnimalDetailsSerializer(CustomModelSerializerMixin, BaseDetailsSeriali
     def validate_diseases_and_abnormalities(self, value):
         return validate_json_field(
             value, models.AnimalDetails, "diseases_and_abnormalities")
+
+    def validate_lifestages(self, value):
+        return validate_json_field(value, models.AnimalDetails, "lifestages")
 
     def validate_sampler(self, value):
         return validate_json_field(
@@ -515,8 +510,20 @@ class WetlandVetegationStructureSerializer(CustomModelSerializerMixin,
 
 class WetlandAnimalDetailsSerializer(CustomModelSerializerMixin,
                                      BaseDetailsSerializer):
-    lifestages = AnimalLifestagesSerializer(required=False)
     vegetation = WetlandVetegationStructureSerializer(required=False)
+
+    def validate_marks(self, value):
+        return validate_json_field(value, models.AnimalDetails, "marks")
+
+    def validate_gender(self, value):
+        return validate_json_field(value, models.AnimalDetails, "gender")
+
+    def validate_diseases_and_abnormalities(self, value):
+        return validate_json_field(
+            value, models.AnimalDetails, "diseases_and_abnormalities")
+
+    def validate_lifestages(self, value):
+        return validate_json_field(value, models.AnimalDetails, "lifestages")
 
     def validate_sampler(self, value):
         return validate_json_field(
@@ -548,8 +555,20 @@ class StreamSubstrateSerializer(CustomModelSerializerMixin,
 
 class StreamAnimalDetailsSerializer(CustomModelSerializerMixin,
                                     BaseDetailsSerializer):
-    lifestages = AnimalLifestagesSerializer(required=False)
     substrate = StreamSubstrateSerializer(required=False)
+
+    def validate_marks(self, value):
+        return validate_json_field(value, models.AnimalDetails, "marks")
+
+    def validate_gender(self, value):
+        return validate_json_field(value, models.AnimalDetails, "gender")
+
+    def validate_diseases_and_abnormalities(self, value):
+        return validate_json_field(
+            value, models.AnimalDetails, "diseases_and_abnormalities")
+
+    def validate_lifestages(self, value):
+        return validate_json_field(value, models.AnimalDetails, "lifestages")
 
     def validate_sampler(self, value):
         return validate_json_field(
@@ -574,7 +593,19 @@ class StreamAnimalDetailsSerializer(CustomModelSerializerMixin,
 
 class PondLakeAnimalDetailsSerializer(CustomModelSerializerMixin,
                                       BaseDetailsSerializer):
-    lifestages = AnimalLifestagesSerializer(required=False)
+
+    def validate_marks(self, value):
+        return validate_json_field(value, models.AnimalDetails, "marks")
+
+    def validate_gender(self, value):
+        return validate_json_field(value, models.AnimalDetails, "gender")
+
+    def validate_diseases_and_abnormalities(self, value):
+        return validate_json_field(
+            value, models.AnimalDetails, "diseases_and_abnormalities")
+
+    def validate_lifestages(self, value):
+        return validate_json_field(value, models.AnimalDetails, "lifestages")
 
     def validate_sampler(self, value):
         return validate_json_field(
@@ -688,7 +719,6 @@ class FernDetailsSerializer(CustomModelSerializerMixin, BaseDetailsSerializer):
 class FloweringPlantDetailsSerializer(CustomModelSerializerMixin, BaseDetailsSerializer):
     disturbance_type = DisturbanceTypeSerializer(required=False)
     earthworm_evidence = EarthwormEvidenceSerializer(required=False)
-    #lifestages = FloweringPlantLifestages(required=False) # FIXME
 
     def validate_aspect(self, value):
         return validate_json_field(
@@ -1499,8 +1529,7 @@ class TaxonOccurrenceSerializer(OccurrenceSerializer):
                 observation.save()
                 instance.observation = observation
             details_data = validated_data.pop("details", {})
-            details_data["lifestages"] = validated_data.pop("lifestages", None)
-            if len(details_data) > 1 or details_data["lifestages"] is not None:
+            if len(details_data) > 0:
                 details = self._process_details(instance, details_data)
                 details.save()
                 instance.details = details
@@ -2110,7 +2139,6 @@ def _process_plant_details(instance, **validated_fields):
             "moisture_regime",
             "ground_surface",
             "general_habitat_category",
-            "disturbance_type",
             "landscape_position",
             "aspect",
             "slope",
@@ -2119,8 +2147,10 @@ def _process_plant_details(instance, **validated_fields):
         dict_table_fields={
             "plant_count": models.PlantCount,
             "tree_canopy_cover": models.CanopyCover,
+        },
+        related_fields={
             "disturbance_type": models.DisturbanceType,
-            "earthworm_evidence": models.EarthwormEvidence
+            "earthworm_evidence": models.EarthwormEvidence,
         },
         field_values=validated_fields.copy()
     )
@@ -2191,8 +2221,10 @@ def _process_stream_animal_details(instance, **validated_fields):
         ),
         dict_table_fields={
             "designated_use": models.StreamDesignatedUse,
-            "substrate": models.StreamSubstrate,
             "water_flow_type": models.WaterFlowType,
+        },
+        related_fields={
+            "substrate": models.StreamSubstrate,
         },
         field_values=validated_fields.copy()
     )

--- a/nfdapi/nfdcore/permissions.py
+++ b/nfdapi/nfdcore/permissions.py
@@ -12,7 +12,7 @@ def get_permissions(user, featuretype_name):
         "animal": (user.is_animal_writer, user.is_animal_publisher),
         "slimemold": (user.is_slimemold_writer, user.is_slimemold_publisher),
         "plant": (user.is_plant_writer, user.is_plant_publisher),
-        "fungis": (user.is_fungus_writer, user.is_fungus_publisher),
+        "fungus": (user.is_fungus_writer, user.is_fungus_publisher),
         "naturalarea": (
             user.is_naturalarea_writer, user.is_naturalarea_publisher),
     }.get(featuretype_name, (False, False))


### PR DESCRIPTION
This PR closes #130 

There is now a `lifestages` form definition, and it includes the `lifecycles` and `plant_count` fields.
The PR includes some other changes due to handling of details for other featuretypes. There were some issues uncovered while testing and they are fixed here too.