### PR TITLE
removed duplicate plant_count from the forms

### DIFF
--- a/nfdapi/nfdcore/form_definitions/conifer-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/conifer-plant-forms.yml
@@ -29,10 +29,6 @@
 - id: details
   label: Details
   fields:
-    - label: plant count
-      field: details.plant_count
-      widget: stringcombo
-      choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime

--- a/nfdapi/nfdcore/form_definitions/fern-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/fern-plant-forms.yml
@@ -29,10 +29,6 @@
 - id: details
   label: Details
   fields:
-    - label: plant count
-      field: details.plant_count
-      widget: stringcombo
-      choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime

--- a/nfdapi/nfdcore/form_definitions/moss-plant-forms.yml
+++ b/nfdapi/nfdcore/form_definitions/moss-plant-forms.yml
@@ -29,10 +29,6 @@
 - id: details
   label: Details
   fields:
-    - label: plant count
-      field: details.plant_count
-      widget: stringcombo
-      choices: nfdcore.models.PlantCount
     - label: area ranges
       field: details.area_ranges
     - label: moisture regime


### PR DESCRIPTION
This PR is connected to #130 
It removes duplicate entries for the `plant_count` form field on some plant subcategories