### PR TITLE
refactored pdf API endpoints to cope with new taxon model

### DIFF
--- a/nfdapi/nfdcore/models.py
+++ b/nfdapi/nfdcore/models.py
@@ -525,12 +525,12 @@ class Taxon(Element):
             self.name = details.name
             self.common_names = details.common_names
             self.rank = details.rank
-            if self.rank.lower() == "kingdom":
-                self.kingdom = details.name
-            else:
-                upper_ranks = itis.get_taxon_upper_ranks(self.tsn)
-                self.upper_ranks = [i.__dict__ for i in upper_ranks[:-1]]
-                self.kingdom = self.upper_ranks[0]["name"]
+            upper_ranks = itis.get_taxon_upper_ranks(self.tsn)
+            self.upper_ranks = {}
+            for index, rank in enumerate(upper_ranks):
+                self.upper_ranks[rank.rank.lower()] = {"index": index}
+                self.upper_ranks[rank.rank.lower()].update(rank.__dict__)
+            self.kingdom = self.upper_ranks["kingdom"]["name"]
 
 
 class Preservative(DictionaryTable):

--- a/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/layer_detail.html
+++ b/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/layer_detail.html
@@ -3,9 +3,11 @@
 
 {% block content %}
 
-<h1>{{ species.common_name }}({{ species.name }})</h1>
-<p>TSN: <strong>{{ species.tsn }}</strong><br>
-    Family: <strong><em>{{ species.family }}</em></strong>
+<h1>{{ taxon.name }}({{ taxon.rank }})</h1>
+<p>TSN: <strong>{{ taxon.tsn }}</strong><br>
+    {% for rank, name in taxon.taxonomic_units %}
+    {{ rank }}: <strong><em>{{ name }}</em></strong><br>
+    {% endfor %}
 </p>
 
 <h2>Individual Characteristics</h2>


### PR DESCRIPTION
This PR closes #212 
The API endpoints for taxon occurrences were refactor to cope with the replacement of `models.Species` with `models.Taxon`. Main changes:

- Changed the JSON representation of a Taxon's upper ranks from a list of objects to a single object that has ranks as keys. This change was necessary in order to allow aggregating taxa according to their ranks. This means that after merging this PR it will be necessary to execute a one-time procedure on the test server in order to convert existing records from the old JSON format to the new one. The commands to run (on a django shell) are:

  ```python
  from nfdcore import models
  for taxon in models.Taxon.objects.all():
      taxon.save()  # force re-population of a taxon's properties based on its TSN
  ```
- Changed the way the aggregation queries are built by replacing the usage of Django's ORM with raw SQL. This was necessary because we are storing a taxon's rank hierarchy in a `JSONField`. The django ORM does not offer full support for performing aggregations on properties of an objects stored in a JSONField, even though this feature is supported by Postgres.