### PR TITLE
fixed empty common names

### DIFF
--- a/nfdapi/nfdcore/form_definitions/common-pages.yml
+++ b/nfdapi/nfdcore/form_definitions/common-pages.yml
@@ -41,7 +41,8 @@ animal_taxon:
       field: taxon.rank
       readonly: true
     - label: Common names
-      field: taxon.common_names.English
+      field: taxon.common_names
+      widget: textarea
       readonly: true
     - label: Kingdom
       field: taxon.kingdom
@@ -155,7 +156,8 @@ plant_taxon:
       field: taxon.rank
       readonly: true
     - label: Common names
-      field: taxon.common_names.English
+      field: taxon.common_names
+      widget: textarea
       readonly: true
     - label: Kingdom
       field: taxon.kingdom
@@ -257,7 +259,8 @@ fungus_taxon:
       field: taxon.rank
       readonly: true
     - label: Common names
-      field: taxon.common_names.English
+      field: taxon.common_names
+      widget: textarea
       readonly: true
     - label: Kingdom
       field: taxon.kingdom

--- a/nfdapi/nfdcore/nfdserializers.py
+++ b/nfdapi/nfdcore/nfdserializers.py
@@ -393,7 +393,15 @@ class TaxonDetailSerializer(serializers.ModelSerializer):
 
         result = OrderedDict()
         for field_name in self.fields:
-            result[field_name] = getattr(instance, field_name)
+            if field_name == "common_names":
+                try:
+                    common_names = sorted(
+                        n.capitalize() for n in instance.common_names)
+                    result[field_name] = "\n".join(common_names)
+                except TypeError:  # common names is None
+                    pass
+            else:
+                result[field_name] = getattr(instance, field_name)
         for rank_name, details in instance.upper_ranks.items():
             result[rank_name] = details["name"]
         return result


### PR DESCRIPTION
This PR closes #220 
The common names are now correctly displayed in the featuretype forms.

A taxon's common names are stored internally as a list. However, the proposed implementation is serializing them as string with newline as a separator (e.g. the internal structure of `["name1", "name2", "name3"]` is serialized to `name1\nname2\nname3`. Such formatting should probably be done on the frontend side instead, in order to allow more flexibility. The current approach was chosen in order to minimize frontend changes.