### PR TITLE
API endpoints for generating PDF reports

### DIFF
--- a/nfdapi/nfdapi/urls.py
+++ b/nfdapi/nfdapi/urls.py
@@ -6,6 +6,7 @@ from rest_framework_jwt.views import refresh_jwt_token
 from rest_framework.routers import DefaultRouter
 
 from nfdcore import views
+from nfdcore import dicttable_views
 from .settings import APP_NAME
 
 router = DefaultRouter()
@@ -14,6 +15,25 @@ router.register("stats", views.OccurrenceAggregatorViewSet, "stats")
 router.register("featuretypes", views.FeatureTypeFormViewSet, "featuretypes")
 router.register("taxon", views.TaxonViewSet, "taxon")
 router.register("taxon_search", views.ItisBackedSearchViewSet, "taxon_search")
+router.register(
+    "report_taxon", views.OccurrenceTaxonReportViewSet, "report_taxon")
+router.register(
+    "report_natural_area",
+    views.OccurrenceNaturalAreaReportViewSet,
+    "report_natural_area"
+)
+router.register("taxon_ranks", views.TaxonRanksViewSet, "taxon_ranks")
+
+# dicttable-based views
+for cls_name in [i for i in dir(dicttable_views) if i.endswith("ViewSet")]:
+    route_name = cls_name.lower().replace("viewset", "")
+    router.register(
+        route_name,
+        getattr(dicttable_views, cls_name),
+        route_name
+    )
+
+
 
 urlpatterns = [
     url(r'^'+APP_NAME+r'api-token-auth/', obtain_jwt_token),
@@ -22,6 +42,10 @@ urlpatterns = [
     # for testing purposes:
     url(r'^'+APP_NAME, include('django.contrib.auth.urls')),
     url(r'^'+APP_NAME+r'rest-auth/', include('rest_auth.urls')),
+    url(
+        r'^'+APP_NAME+r'api-auth/',
+        include('rest_framework.urls', namespace="rest_framework")
+    ),
 
     url(r'^'+APP_NAME+r'admin/', admin.site.urls),
 

--- a/nfdapi/nfdcore/admin.py
+++ b/nfdapi/nfdcore/admin.py
@@ -11,6 +11,16 @@ from pygments.formatters import HtmlFormatter
 from . import models
 
 
+@admin.register(models.OccurrenceTaxon)
+class OccurrenceTaxonAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "taxon",
+        "location",
+        "observation",
+    )
+
+
 @admin.register(models.Taxon)
 class TaxonAdmin(admin.ModelAdmin):
     list_display = (

--- a/nfdapi/nfdcore/constants.py
+++ b/nfdapi/nfdcore/constants.py
@@ -1,0 +1,60 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+# the following list was obtained from ITIS DB with the query:
+# SELECT DISTINCT rank_id, lower(rank_name)
+# FROM taxon_unit_types
+# ORDER BY rank_id
+TAXON_RANKS = [
+    "kingdom",
+    "subkingdom",
+    "infrakingdom",
+    "superphylum",
+    "superdivision",
+    "division",
+    "phylum",
+    "subdivision",
+    "subphylum",
+    "infraphylum",
+    "infradivision",
+    "parvphylum",
+    "parvdivision",
+    "superclass",
+    "class",
+    "subclass",
+    "infraclass",
+    "superorder",
+    "order",
+    "suborder",
+    "infraorder",
+    "section",
+    "subsection",
+    "superfamily",
+    "family",
+    "subfamily",
+    "tribe",
+    "subtribe",
+    "genus",
+    "subgenus",
+    "section",
+    "subsection",
+    "species",
+    "subspecies",
+    "variety",
+    "form",
+    "race",
+    "subvariety",
+    "stirp",
+    "form",
+    "morph",
+    "aberration",
+    "subform",
+    "unspecified",
+]

--- a/nfdapi/nfdcore/dicttable_views.py
+++ b/nfdapi/nfdcore/dicttable_views.py
@@ -1,0 +1,145 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+"""View classes for models that inherit from `models.DictionaryTable`"""
+
+from rest_framework import viewsets
+
+from . import models
+from .serializers import GenericDictTableSerializer
+
+
+def dict_table_viewset_factory(dict_table_model):
+    """A class factory for generating viewsets for dicttable based models
+
+    This function acts as a class factory. It generates classes that derive
+    from django-rest-framework's ``viewsets.ReadOnlyModelViewSet``.
+    It returns a viewset class that can be used to generate API endpoints for
+    the various models that are based on ``nfdcore.models.DictionaryTable``.
+
+    The code used here is somewhat obscure, as it is based on meta-programming
+    techniques. This approach was chosen in order to reduce the number of
+    lines of code that would need to be written in order to generate viewsets
+    for all of the existing dicttable models.
+
+    The code itself just calls ``type()`` with the correct arguments in order
+    to generate a class at runtime.
+
+    Examples
+    --------
+
+    The following example defines the ``ReservationViewSet`` class:
+
+    >>> ReservationViewSet = dict_table_viewset_factory(models.Reservation)
+
+    Without the current function, the equivalent code would be:
+
+    >>> Class ReservationViewSet(viewsets.ReadOnlyModelViewSet):
+    ...     queryset = models.Reservation.objects.all()
+    ...     serializer_class = GenericDictTableSerializer
+    ...
+    ...     def get_serializer(self, *args, **kwargs):
+    ...         return self.serializer_class(
+    ...             model=models.Reservation, *args, **kwargs)
+
+    """
+
+    def get_serializer(self, *args, **kwargs):
+        return self.serializer_class(model=dict_table_model, *args, **kwargs)
+
+    cls_name = "{}ViewSet".format(dict_table_model.__name__)
+    cls_attrs = {
+        "queryset": dict_table_model.objects.all(),
+        "serializer_class": GenericDictTableSerializer,
+        "get_serializer": get_serializer,
+    }
+
+    return type(
+        cls_name,
+        (viewsets.ReadOnlyModelViewSet,),
+        cls_attrs
+    )
+
+
+_MODELS_TO_SERIALIZE = [
+    models.AnimalLifestages,
+    models.AquaticHabitatCategory,
+    models.AquaticSampler,
+    models.Aspect,
+    models.BedrockAndOutcrops,
+    models.CanopyCover,
+    models.ChannelType,
+    models.CMSensitivity,
+    models.CmStatus,  # this is extended
+    models.ConiferLifestages,
+    models.DayTime,
+    models.DiseasesAndAbnormalities,
+    models.ElementType,
+    models.FernLifestages,
+    models.FloweringPlantLifestages,
+    models.FungalAssociationType,
+    models.FungusApparentSubstrate,
+    models.Gender,
+    models.GeneralHabitatCategory,
+    models.GlacialDeposit,
+    models.GlacialDepositPleistoceneAge,
+    models.GroundSurface,
+    models.GRank,
+    models.HmfeiLocalAbundance,
+    models.IucnRedListCategory,
+    models.LakeMicrohabitat,
+    models.LandscapePosition,
+    models.LeapLandCover,
+    models.LoticHabitatType,
+    models.Marks,
+    models.MoistureRegime,
+    models.MossLifestages,
+    models.MushroomGroup,
+    models.MushroomGrowthForm,
+    models.MushroomOdor,
+    models.MushroomVerticalLocation,
+    models.NaturalAreaCondition,
+    models.NaturalAreaType,
+    models.NRank,
+    models.OccurrenceCategory,
+    models.PlantCount,
+    models.PondLakeType,
+    models.PondLakeUse,
+    models.Preservative,
+    models.RecordOrigin,
+    models.RecordingStation,
+    models.RegionalFrequency,
+    models.RegionalStatus,  # this is extended
+    models.Repository,
+    models.Reservation,
+    models.Season,
+    models.ShorelineType,
+    models.SlimeMoldClass,  # this is extended
+    models.SlimeMoldMedia,
+    models.Slope,
+    models.SRank,
+    models.Storage,
+    models.StreamDesignatedUse,
+    models.TerrestrialSampler,
+    models.TerrestrialStratum,
+    models.UsfwsStatus,
+    models.WaterFlowType,
+    models.WaterSource,
+    models.Watershed,
+    models.WetlandConnectivity,
+    models.WetlandHabitatFeature,
+    models.WetlandLocation,
+    models.WetlandType,
+]
+
+for cls_model in _MODELS_TO_SERIALIZE:
+    serializer_cls = dict_table_viewset_factory(cls_model)
+    # put serializer_cls in module's namespace so it can be easily accessed
+    globals()[serializer_cls.__name__] = serializer_cls

--- a/nfdapi/nfdcore/filters.py
+++ b/nfdapi/nfdcore/filters.py
@@ -1,0 +1,190 @@
+#########################################################################
+#
+# Copyright 2018, GeoSolutions Sas.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#########################################################################
+
+"""Filterset classes for clevmetro"""
+
+from django.db.models import Q
+from django_filters import rest_framework as django_filters
+from rest_framework.filters import BaseFilterBackend
+
+from . import constants
+from . import models
+
+
+class OccurrenceTaxonFilterSet(django_filters.FilterSet):
+    featuresubtype = django_filters.filters.CharFilter(
+        name="occurrence_cat__code"
+    )
+    taxon = django_filters.filters.CharFilter(
+        method="filter_ranks",
+    )
+    reservation = django_filters.filters.CharFilter(
+        name="location__reservation",
+        lookup_expr="icontains",
+    )
+    watershed = django_filters.filters.CharFilter(
+        name="location__watershed",
+        lookup_expr="icontains",
+    )
+    cm_status = django_filters.filters.ModelChoiceFilter(
+        name="taxon__cm_status__code",
+        queryset=models.CmStatus.objects.all()
+    )
+
+    def filter_ranks(self, queryset, name, value):
+        """Filter for the input name in all available hierarchical ranks
+
+        This method builds a chained OR lookup using django's Q objects. This
+        is suitable for searching in a Taxon's taxonomic ranks, which are
+        stored in a JSONField on ``models.Taxon``. This enables  searching
+        for a name in any of the taxon's ranks.
+
+        """
+
+        lookup_pattern = "taxon__upper_ranks__{}__name__icontains"
+        q_object = Q(
+            **{lookup_pattern.format(constants.TAXON_RANKS[0]): value})
+        for rank in constants.TAXON_RANKS[1:]:
+            q_object = q_object | Q(**{lookup_pattern.format(rank): value})
+        return queryset.filter(q_object)
+
+    class Meta:
+        model = models.OccurrenceTaxon
+        fields = ['location', 'released', 'verified', 'taxon']
+
+
+class NaturalAreaFilter(django_filters.FilterSet):
+    featuresubtype = django_filters.filters.CharFilter(
+        name="occurrence_cat__code")
+    cm_status = django_filters.filters.ModelChoiceFilter(
+        name="element__cm_status__code",
+        queryset=models.CmStatus.objects.all()
+    )
+
+    class Meta:
+        model = models.OccurrenceNaturalArea
+        fields = ['released', 'verified']
+
+
+class CharInFilter(django_filters.BaseInFilter, django_filters.CharFilter):
+    pass
+
+
+class ReportTaxonFilterBackend(BaseFilterBackend):
+
+    def filter_queryset(self, request, queryset, view):
+        rank_name = request.query_params.get("rank_name", "species").lower()
+        rank_value = request.query_params.get("rank_value")
+        if rank_value:
+            lookup = "taxon__upper_ranks__{}__name__icontains".format(
+                rank_name)
+            result = queryset.filter(**{lookup: rank_value})
+        else:
+            result = queryset
+        return result
+
+
+class BaseOccurrenceReportFilterSet(django_filters.FilterSet):
+    reservation = django_filters.CharFilter(method="filter_reservation")
+    watershed = django_filters.CharFilter(method="filter_watershed")
+    observer = django_filters.CharFilter(name="observation__reporter__name")
+    observation_date = django_filters.DateFromToRangeFilter(
+        name="observation__observation_date")
+
+    def filter_reservation(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "location__reservation__icontains")
+
+    def filter_watershed(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "location__watershed__icontains")
+
+    def _filter_json_field(self, queryset, name, value, lookup_pattern):
+        filter_values = [i.strip() for i in value.split(",")]
+        q_object = Q(**{lookup_pattern: filter_values[0]})
+        for filter_value in filter_values[1:]:
+            q_object = q_object | Q(**{lookup_pattern: filter_value})
+        print("q_object: {}".format(q_object))
+        return queryset.filter(q_object)
+
+    class Meta:
+        model = models.OccurrenceTaxon
+        fields = [
+            "reservation",
+            "watershed",
+            "observer",
+            "observation_date",
+        ]
+
+
+class OccurrenceTaxonReportFilterSet(BaseOccurrenceReportFilterSet):
+    global_status = django_filters.CharFilter(method="filter_global_status")
+    state_status = django_filters.CharFilter(method="filter_state_status")
+    cm_status = django_filters.CharFilter(method="filter_cm_status")
+    county = CharInFilter(name="location__county")
+    quad_name = CharInFilter(name="location__quad_name")
+    quad_number = CharInFilter(name="location__quad_number")
+
+    def filter_global_status(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "taxon__g_rank__code__icontains")
+
+    def filter_state_status(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "taxon__s_rank__code__icontains")
+
+    def filter_cm_status(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "taxon__cm_status__code__icontains")
+
+    class Meta:
+        model = models.OccurrenceTaxon
+        fields = [
+            "reservation",
+            "watershed",
+            "county",
+            "quad_name",
+            "quad_number",
+            "global_status",
+            "state_status",
+            "cm_status",
+            "observer",
+            "observation_date",
+        ]
+
+
+class OccurrenceNaturalAreaReportFilterSet(BaseOccurrenceReportFilterSet):
+    global_status = django_filters.CharFilter(method="filter_global_status")
+    state_status = django_filters.CharFilter(method="filter_state_status")
+    cm_status = django_filters.CharFilter(method="filter_cm_status")
+
+    def filter_global_status(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "element__g_rank__code__icontains")
+
+    def filter_state_status(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "element__s_rank__code__icontains")
+
+    def filter_cm_status(self, queryset, name, value):
+        return self._filter_json_field(
+            queryset, name, value, "element__cm_status__code__icontains")
+
+    class Meta:
+        model = models.OccurrenceNaturalArea
+        fields = [
+            "reservation",
+            "watershed",
+            "global_status",
+            "state_status",
+            "cm_status",
+            "observer",
+            "observation_date",
+        ]

--- a/nfdapi/nfdcore/initmodel.py
+++ b/nfdapi/nfdcore/initmodel.py
@@ -2,7 +2,7 @@ from django.utils import timezone
 import reversion
 
 from . import models
-from . import nfdserializers
+from . import serializers
 
 LONTRA_TSN = 180549
 BEAR_TSN = 180544
@@ -1100,7 +1100,7 @@ def insert_test_taxa(clean=False):
 def insert_test_data(clean=True):
     if clean:
         for feat in models.OccurrenceTaxon.objects.all():
-            nfdserializers.delete_object_and_children(feat)
+            serializers.delete_object_and_children(feat)
 
     """
     plant_cat = models.OccurrenceCategory.objects.get(code='pl')

--- a/nfdapi/nfdcore/models.py
+++ b/nfdapi/nfdcore/models.py
@@ -276,6 +276,7 @@ class RecordingStation(DictionaryTable):
     pass
 
 
+@python_2_unicode_compatible
 @reversion.register()
 class OccurrenceObservation(models.Model):
     observation_date = models.DateField(blank=True, null=True)
@@ -288,6 +289,13 @@ class OccurrenceObservation(models.Model):
     reporter = models.ForeignKey(PointOfContact, on_delete=models.CASCADE, related_name='reporter')
     recorder = models.ForeignKey(PointOfContact, on_delete=models.CASCADE, blank=True, null=True, related_name='recorder')
     verifier = models.ForeignKey(PointOfContact, on_delete=models.CASCADE, blank=True, null=True, related_name='verifier')
+
+    def __str__(self):
+        return "{reporter}{observation_date}".format(
+            reporter=self.reporter.name,
+            observation_date=" ({})".format(
+                self.observation_date) if self.observation_date else ""
+        )
 
 
 @reversion.register()
@@ -323,6 +331,7 @@ class Watershed(DictionaryTable):
     pass
 
 
+@python_2_unicode_compatible
 class Location(models.Model):
     site_description = models.TextField(blank=True, null=True, default='')
     reservation = JSONField(blank=True, null=True)
@@ -332,6 +341,11 @@ class Location(models.Model):
 
     class Meta:
         abstract = True
+
+    def __str__(self):
+        reservation = ", ".join(self.reservation) if self.reservation else None
+        watershed = ", ".join(self.watershed) if self.watershed else None
+        return "Reservation: {} - Watershed: {}".format(reservation, watershed)
 
 
 @reversion.register()
@@ -819,7 +833,6 @@ class SlimeMoldClass(DictionaryTableExtended):
 
 class SlimeMoldMedia(DictionaryTable):
     pass
-
 
 @reversion.register(follow=['taxondetails_ptr'])
 class SlimeMoldDetails(TaxonDetails):

--- a/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/natural_area_occurrence_report.html
+++ b/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/natural_area_occurrence_report.html
@@ -1,0 +1,127 @@
+{% extends "nfdrenderers/pdf/base.html" %}
+{% load i18n %}
+
+{% block layout_style %}
+<style type="text/css">
+    @page {
+        size: landscape;
+        margin-top: 2.5cm;
+        margin-right: 0.8cm;
+        margin-left: 0.8cm;
+        margin-bottom: 1cm;
+    }
+    #occurrences {
+        border: #0a0b30 solid 1px;
+        font-size: small;
+    }
+    strong {
+        color: #1D5C1E;
+    }
+
+</style>
+{% endblock%}
+
+
+{% block content %}
+
+<h1>Natural Features Report</h1>
+{% if filters|length > 0 %}
+    <p>
+        <strong>Filters</strong><br>
+        <ul>
+            {% if filters.natural_area_code_nac %}
+                <li>Natural area code: <strong>{{ filters.natural_area_code_nac }}</strong></li>
+            {% endif %}
+            {% if filters.reservation %}
+                <li>Reservation: <strong>{{ filters.reservation }}</strong></li>
+            {% endif %}
+            {% if filters.watershed %}
+                <li>Watershed: <strong>{{ filters.watershed }}</strong></li>
+            {% endif %}
+            {% if filters.global_status %}
+                <li>Global Status: <strong>{{ filters.global_status }}</strong></li>
+            {% endif %}
+            {% if filters.state_status %}
+                <li>State Status: <strong>{{ filters.state_status }}</strong></li>
+            {% endif %}
+            {% if filters.cm_status %}
+                <li>CM Status: <strong>{{ filters.cm_status }}</strong></li>
+            {% endif %}
+            {% if filters.observer %}
+                <li>Observer: <strong>{{ filters.observer }}</strong></li>
+            {% endif %}
+            {% if filters.observation_date %}
+                <li>Observation date: <strong>{{ filters.observation_date }}</strong></li>
+            {% endif %}
+        </ul>
+    </p>
+{% endif %}
+<p>
+    <strong>Occurrences</strong><br>
+    {% if occurrences|length > 0 %}
+        <table repeat="1" id="occurrences">
+            <tr>
+                <th style="width: 30px">List ID</th>
+                <th style="width: 30px">DB ID</th>
+                <th>Natural area code</th>
+                <th>Observation date</th>
+                {% if not filters.observer %}
+                <th>Observer</th>
+                {% endif %}
+                <th>Site description</th>
+                {% if not filters.reservation %}
+                <th>Reservation</th>
+                {% endif %}
+                <th>Watershed</th>
+                {% if not filters.state_status %}
+                <th>State Status</th>
+                {% endif %}
+                {% if not filters.federal_status %}
+                <th>Federal Status</th>
+                {% endif %}
+                {% if not filters.global_status %}
+                <th>Global Status</th>
+                {% endif %}
+                {% if not filters.cm_status %}
+                <th>CM Status</th>
+                {% endif %}
+                <th style="width: 70px">Latitude</th>
+                <th style="width: 70px">Longitude</th>
+            </tr>
+            {% for occurrence in occurrences %}
+            <tr>
+                <td>{{ occurrence.index}}</td>
+                <td>{{ occurrence.id }}</td>
+                <td>{{ occurrence.natural_area_code_nac|default_if_none:"-" }}</td>
+                <td>{{ occurrence.observation_date|default_if_none:"-" }}</td>
+                {% if not filters.observer %}
+                <td>{{ occurrence.observer|default_if_none:"-" }}</td>
+                {% endif %}
+                <td>{{ occurrence.site_description|default_if_none:"-" }}</td>
+                {% if not filters.reservation %}
+                <td>{{ occurrence.reservation|default_if_none:"-" }}</td>
+                {% endif %}
+                <td>{{ occurrence.watershed|default_if_none:"-" }}</td>
+                {% if not filters.state_status %}
+                <td>{{ occurrence.state_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.federal_status %}
+                <td>{{ occurrence.federal_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.global_status %}
+                <td>{{ occurrence.global_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.cm_status %}
+                <td>{{ occurrence.cm_status|default_if_none:"-" }}</td>
+                {% endif %}
+                <td>{{ occurrence.latitude|default_if_none:"-"|floatformat:"3" }}</td>
+                <td>{{ occurrence.longitude|default_if_none:"-"|floatformat:"3" }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        <p>The current filters did not match any occurrences</p>
+    {% endif %}
+</p>
+
+{% endblock content %}

--- a/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
+++ b/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
@@ -1,0 +1,140 @@
+{% extends "nfdrenderers/pdf/base.html" %}
+{% load i18n %}
+
+{% block layout_style %}
+<style type="text/css">
+    @page {
+        size: landscape;
+        margin-top: 2.5cm;
+        margin-right: 0.8cm;
+        margin-left: 0.8cm;
+        margin-bottom: 1cm;
+    }
+    #occurrences {
+        border: #0a0b30 solid 1px;
+        font-size: small;
+    }
+    strong {
+        color: #1D5C1E;
+    }
+
+</style>
+{% endblock%}
+
+
+{% block content %}
+
+<h1>Natural Features Report</h1>
+{% if filters|length > 0 %}
+    <p>
+        <strong>Filters</strong><br>
+        <ul>
+            {% if filters.feature %}
+                <li>Feature: <strong>{{ filters.feature }}</strong></li>
+            {% endif %}
+            {% if filters.reservation %}
+                <li>Reservation: <strong>{{ filters.reservation }}</strong></li>
+            {% endif %}
+            {% if filters.watershed %}
+                <li>Watershed: <strong>{{ filters.watershed }}</strong></li>
+            {% endif %}
+            {% if filters.county %}
+                <li>County: <strong>{{ filters.county }}</strong></li>
+            {% endif %}
+            {% if filters.quad %}
+                <li>Quad: <strong>{{ filters.quad }}</strong></li>
+            {% endif %}
+            {% if filters.global_status %}
+                <li>Global Status: <strong>{{ filters.global_status }}</strong></li>
+            {% endif %}
+            {% if filters.state_status %}
+                <li>State Status: <strong>{{ filters.state_status }}</strong></li>
+            {% endif %}
+            {% if filters.cm_status %}
+                <li>CM Status: <strong>{{ filters.cm_status }}</strong></li>
+            {% endif %}
+            {% if filters.observer %}
+                <li>Observer: <strong>{{ filters.observer }}</strong></li>
+            {% endif %}
+            {% if filters.observation_date %}
+                <li>Observation date: <strong>{{ filters.observation_date }}</strong></li>
+            {% endif %}
+        </ul>
+    </p>
+{% endif %}
+<p>
+    <strong>Occurrences</strong><br>
+    {% if occurrences|length > 0 %}
+        <table repeat="1" id="occurrences">
+            <tr>
+                <th style="width: 30px">List ID</th>
+                <th style="width: 30px">DB ID</th>
+                <th>Genus</ths>
+                <th>Species</th>
+                <th>Common Name</th>
+                <th>Observation date</th>
+                {% if not filters.observer %}
+                    <th>Observer</th>
+                {% endif %}
+                <th>Site description</th>
+                {% if not filters.reservation %}
+                    <th>Reservation</th>
+                {% endif %}
+                {% if not filters.watershed %}
+                    <th>Watershed</th>
+                {% endif %}
+                {% if not filters.state_status %}
+                    <th>State Status</th>
+                {% endif %}
+                {% if not filters.federal_status %}
+                    <th>Federal Status</th>
+                {% endif %}
+                {% if not filters.global_status %}
+                    <th>Global Status</th>
+                {% endif %}
+                {% if not filters.cm_status %}
+                    <th>CM Status</th>
+                {% endif %}
+                <th style="width: 70px">Latitude</th>
+                <th style="width: 70px">Longitude</th>
+            </tr>
+            {% for occurrence in occurrences %}
+            <tr>
+                <td>{{ occurrence.index}}</td>
+                <td>{{ occurrence.id }}</td>
+                <td>{{ occurrence.genus|default_if_none:"-" }}</td>
+                <td>{{ occurrence.species|default_if_none:"-" }}</td>
+                <td>{{ occurrence.common_name|default_if_none:"-" }}</td>
+                <td>{{ occurrence.observation_date|default_if_none:"-" }}</td>
+                {% if not filters.observer %}
+                    <td>{{ occurrence.observer|default_if_none:"-" }}</td>
+                {% endif %}
+                <td>{{ occurrence.site_description|default_if_none:"-" }}</td>
+                {% if not filters.reservation %}
+                    <td>{{ occurrence.reservation|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.watershed %}
+                    <td>{{ occurrence.watershed|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.state_status %}
+                    <td>{{ occurrence.state_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.federal_status %}
+                    <td>{{ occurrence.federal_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.global_status %}
+                    <td>{{ occurrence.global_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if not filters.cm_status %}
+                    <td>{{ occurrence.cm_status|default_if_none:"-" }}</td>
+                {% endif %}
+                <td>{{ occurrence.latitude|default_if_none:"-"|floatformat:"3" }}</td>
+                <td>{{ occurrence.longitude|default_if_none:"-"|floatformat:"3" }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        <p>The current filters did not match any occurrences</p>
+    {% endif %}
+</p>
+{% endblock content %}


### PR DESCRIPTION
This PR is connected to #234 and it is connected to #236 

It adds API endpoints for the generation of PDF reports for both taxon and natural area occurrences.

In addition to these PDF generation endpoints, there are also several new endpoints for querying the values of all models that inherit from `nfdcore.models.DictionaryTable`

### PDF generation endpoints

The following endpoints are now available:

```
/nfdapi/report_taxon/
/nfdapi/report_natural_area/
```

They can be used for getting back reports of taxon and natural area occurrences. Accepted parameters:

* `format={json,pdf}` - For controlling the representation generation by the server. The default value is `json`

* `state_status` - This is used for filtering occurrences according to their `s_rank` attribute. Expected values are the `SRank` instance's corresponding `code` attribute. Several values are accepted and should be delimited with commas. Example: `/nfdapi/report_taxon/?state_status=S1S2,S3S4`

* `global_status` - This is used for filtering occurrences according to their `g_rank` attribute. Implementation is similar to the `state_status` parameter. Example: `/nfdapi/report_taxon/?global_status=G3,G1`

* `cm_status` - This is used for filtering occurrences according to their `cm_status` attribute. Implementation is similar to the `state_status` parameter. Example: `/nfdapi/report_taxon/?state_status=S1S2,S3S4`

* `reservation` - Example: `/nfdapi/report_taxon/?reservation=AC,BD`

* `watershed` - Example: `/nfdapi/report_taxon/?watershed=1,2,3`

* `observer` - Example: `/nfdapi/report_taxon/?observer=john`

* `observation_date_0` - Start range for the temporal filter on occurrences. If not supplied there will be no lower bound on the date filtering. 
  Example: `/nfdapi/report_taxon/?observation_date_0=2018-01-01`

* `observation_date_1` - End range for the temporal filter on occurrences. If not supplied there will be no upper bound on the date filtering. 
  Example: `/nfdapi/report_taxon/?observation_date_1=2018-01-31`

The following parameters are only available in the **taxon occurrences endpoint**:

* `rank_name` - Name of the rank that will be used for filtering. 
  Example: `/nfdapi/report_taxon/?rank_name=family`

* `rank_value` - Search text for the rank. Example: `/nfdapi/report_taxon/?rank_value=amanita`

* `county`

* `quad_name`

* `quad_nmber`

The following parameters are only available for the **natural areas endpoint**:

* `element__natural_area_code_nac`


### Additional API endpoints

The following new endpoints are available:

```
/nfdapi/taxon_ranks/  # only one that is not based on DictionaryTable objects
/nfdapi/animallifestages/
/nfdapi/aquatichabitatcategory/
/nfdapi/aquaticsampler/
/nfdapi/aspect/
/nfdapi/bedrockandoutcrops/
/nfdapi/cmsensitivity/
/nfdapi/canopycover/
/nfdapi/channeltype/
/nfdapi/cmstatus/
/nfdapi/coniferlifestages/
/nfdapi/daytime/
/nfdapi/diseasesandabnormalities/
/nfdapi/elementtype/
/nfdapi/fernlifestages/
/nfdapi/floweringplantlifestages/
/nfdapi/fungalassociationtype/
/nfdapi/fungusapparentsubstrate/
/nfdapi/grank/
/nfdapi/gender/
/nfdapi/generalhabitatcategory/
/nfdapi/glacialdepositpleistoceneage/
/nfdapi/glacialdeposit/
/nfdapi/groundsurface/
/nfdapi/hmfeilocalabundance/
/nfdapi/iucnredlistcategory/
/nfdapi/lakemicrohabitat/
/nfdapi/landscapeposition/
/nfdapi/leaplandcover/
/nfdapi/lotichabitattype/
/nfdapi/marks/
/nfdapi/moistureregime/
/nfdapi/mosslifestages/
/nfdapi/mushroomgroup/
/nfdapi/mushroomgrowthform/
/nfdapi/mushroomodor/
/nfdapi/mushroomverticallocation/
/nfdapi/nrank/
/nfdapi/naturalareacondition/
/nfdapi/naturalareatype/
/nfdapi/occurrencecategory/
/nfdapi/plantcount/
/nfdapi/pondlaketype/
/nfdapi/pondlakeuse/
/nfdapi/preservative/
/nfdapi/recordorigin/
/nfdapi/recordingstation/
/nfdapi/regionalfrequency/
/nfdapi/regionalstatus/
/nfdapi/repository/
/nfdapi/reservation/
/nfdapi/srank/
/nfdapi/season/
/nfdapi/shorelinetype/
/nfdapi/slimemoldclass/
/nfdapi/slimemoldmedia/
/nfdapi/slope/
/nfdapi/storage/
/nfdapi/streamdesignateduse/
/nfdapi/terrestrialsampler/
/nfdapi/terrestrialstratum/
/nfdapi/usfwsstatus/
/nfdapi/waterflowtype/
/nfdapi/watersource/
/nfdapi/watershed/
/nfdapi/wetlandconnectivity/
/nfdapi/wetlandhabitatfeature/
/nfdapi/wetlandlocation/
/nfdapi/wetlandtype/
```

These endpoints may be queried by the frontend in order to obtain the necessary values for constructing meaningful requests for the PDF generation.