### PR TITLE
added the query paramters that control table columns in the pdf report

### DIFF
--- a/nfdapi/nfdrenderers/pdf.py
+++ b/nfdapi/nfdrenderers/pdf.py
@@ -262,11 +262,21 @@ class OccurrenceTaxonReportRenderer(BaseOccurrenceReportRenderer):
             county=query_params.get("county"),
             quad=_get_quad(query_params),
         )
+        default_columns = [
+            "list_id",
+            "genus",
+            "common_name",
+            "cm_status",
+            "latitude",
+            "longitude",
+        ]
         return render_to_pdf(
             "nfdrenderers/pdf/taxon_occurrence_report.html",
             context={
                 "occurrences": occurrences,
                 "filters": {k: v for k, v in filters.items() if v},
+                "table_columns": get_table_columns(
+                    query_params, default_columns),
             }
         )
 
@@ -281,19 +291,42 @@ class OccurrenceNaturalAreaReportRenderer(BaseOccurrenceReportRenderer):
             occurrences.append(occurrence)
         query_params = renderer_context["request"].query_params.dict()
         filters = self.get_filters(query_params)
-        print("filters: {}".format(filters))
         filters.update(
             natural_area_code_nac=query_params.get("natural_area_code_nac"),
             general_description=query_params.get("general_description"),
             notable_features=query_params.get("notable_features"),
         )
+        default_columns = [
+            "list_id",
+            "genus",
+            "natural_area_code",
+            "general_description",
+            "cm_status",
+            "latitude",
+            "longitude",
+        ]
         return render_to_pdf(
             "nfdrenderers/pdf/natural_area_occurrence_report.html",
             context={
                 "occurrences": occurrences,
                 "filters": {k: v for k, v in filters.items() if v},
+                "table_columns": get_table_columns(
+                    query_params, default_columns),
             }
         )
+
+
+def get_table_columns(query_params, defaults, prefix="show_"):
+    columns = set(defaults)
+    for param, value in query_params.items():
+        name = param.replace(prefix, "")
+        bool_value = value.lower() in ("true", "1")
+        if param.startswith(prefix):
+            if bool_value:
+                columns.add(name)
+            else:
+                columns.discard(name)
+    return list(columns)
 
 
 def get_status_description(status_model, code):

--- a/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/natural_area_occurrence_report.html
+++ b/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/natural_area_occurrence_report.html
@@ -61,61 +61,99 @@
     {% if occurrences|length > 0 %}
         <table repeat="1" id="occurrences">
             <tr>
-                <th style="width: 30px">List ID</th>
-                <th style="width: 30px">DB ID</th>
-                <th>Natural area code</th>
-                <th>Observation date</th>
-                {% if not filters.observer %}
-                <th>Observer</th>
+                {% if "list_id" in table_columns %}
+                    <th style="width: 30px">List ID</th>
                 {% endif %}
-                <th>Site description</th>
-                {% if not filters.reservation %}
-                <th>Reservation</th>
+                {% if "db_id" in table_columns %}
+                    <th style="width: 30px">DB ID</th>
                 {% endif %}
-                <th>Watershed</th>
-                {% if not filters.state_status %}
-                <th>State Status</th>
+                {% if "natural_area_code" in table_columns %}
+                    <th>Natural area code</th>
                 {% endif %}
-                {% if not filters.federal_status %}
-                <th>Federal Status</th>
+                {% if "general_description" in table_columns %}
+                    <th>General description</th>
                 {% endif %}
-                {% if not filters.global_status %}
-                <th>Global Status</th>
+                {% if "observation_date" in table_columns %}
+                    <th>Observation date</th>
                 {% endif %}
-                {% if not filters.cm_status %}
-                <th>CM Status</th>
+                {% if "observer" in table_columns %}
+                    <th>Observer</th>
                 {% endif %}
-                <th style="width: 70px">Latitude</th>
-                <th style="width: 70px">Longitude</th>
+                {% if "site_description" in table_columns %}
+                    <th>Site description</th>
+                {% endif %}
+                {% if "reservation" in table_columns %}
+                    <th>Reservation</th>
+                {% endif %}
+                {% if "watershed" in table_columns %}
+                    <th>Watershed</th>
+                {% endif %}
+                {% if "state_status" in table_columns %}
+                    <th>State Status</th>
+                {% endif %}
+                {% if "federal_status" in table_columns %}
+                    <th>Federal Status</th>
+                {% endif %}
+                {% if "global_status" in table_columns %}
+                    <th>Global Status</th>
+                {% endif %}
+                {% if "cm_status" in table_columns %}
+                    <th>CM Status</th>
+                {% endif %}
+                {% if "latitude" in table_columns %}
+                    <th style="width: 70px">Latitude</th>
+                {% endif %}
+                {% if "longitude" in table_columns %}
+                    <th style="width: 70px">Longitude</th>
+                {% endif %}
             </tr>
             {% for occurrence in occurrences %}
             <tr>
-                <td>{{ occurrence.index}}</td>
-                <td>{{ occurrence.id }}</td>
-                <td>{{ occurrence.natural_area_code_nac|default_if_none:"-" }}</td>
-                <td>{{ occurrence.observation_date|default_if_none:"-" }}</td>
-                {% if not filters.observer %}
-                <td>{{ occurrence.observer|default_if_none:"-" }}</td>
+                {% if "list_id" in table_columns %}
+                    <td>{{ occurrence.index}}</td>
                 {% endif %}
-                <td>{{ occurrence.site_description|default_if_none:"-" }}</td>
-                {% if not filters.reservation %}
-                <td>{{ occurrence.reservation|default_if_none:"-" }}</td>
+                {% if "db_id" in table_columns %}
+                    <td>{{ occurrence.id }}</td>
                 {% endif %}
-                <td>{{ occurrence.watershed|default_if_none:"-" }}</td>
-                {% if not filters.state_status %}
-                <td>{{ occurrence.state_status|default_if_none:"-" }}</td>
+                {% if "natural_area_code" in table_columns %}
+                    <td>{{ occurrence.natural_area_code_nac|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.federal_status %}
-                <td>{{ occurrence.federal_status|default_if_none:"-" }}</td>
+                {% if "general_description" in table_columns %}
+                <td>{{ occurrence.general_description|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.global_status %}
-                <td>{{ occurrence.global_status|default_if_none:"-" }}</td>
+                {% if "observation_date" in table_columns %}
+                    <td>{{ occurrence.observation_date|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.cm_status %}
-                <td>{{ occurrence.cm_status|default_if_none:"-" }}</td>
+                {% if "observer" in table_columns %}
+                    <td>{{ occurrence.observer|default_if_none:"-" }}</td>
                 {% endif %}
-                <td>{{ occurrence.latitude|default_if_none:"-"|floatformat:"3" }}</td>
-                <td>{{ occurrence.longitude|default_if_none:"-"|floatformat:"3" }}</td>
+                {% if "site_description" in table_columns %}
+                    <td>{{ occurrence.site_description|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "reservation" in table_columns %}
+                    <td>{{ occurrence.reservation|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "watershed" in table_columns %}
+                    <td>{{ occurrence.watershed|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "state_status" in table_columns %}
+                    <td>{{ occurrence.state_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "federal_status" in table_columns %}
+                    <td>{{ occurrence.federal_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "global_status" in table_columns %}
+                    <td>{{ occurrence.global_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "cm_status" in table_columns %}
+                    <td>{{ occurrence.cm_status|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "latitude" in table_columns %}
+                    <td>{{ occurrence.latitude|default_if_none:"-"|floatformat:"3" }}</td>
+                {% endif %}
+                {% if "longitude" in table_columns %}
+                    <td>{{ occurrence.longitude|default_if_none:"-"|floatformat:"3" }}</td>
+                {% endif %}
             </tr>
             {% endfor %}
         </table>

--- a/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
+++ b/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
@@ -67,69 +67,105 @@
     {% if occurrences|length > 0 %}
         <table repeat="1" id="occurrences">
             <tr>
-                <th style="width: 30px">List ID</th>
-                <th style="width: 30px">DB ID</th>
-                <th>Genus</ths>
-                <th>Species</th>
-                <th>Common Name</th>
-                <th>Observation date</th>
-                {% if not filters.observer %}
+                {% if "list_id" in table_columns %}
+                    <th style="width: 30px">List ID</th>
+                {% endif %}
+                {% if "db_id" in table_columns %}
+                    <th style="width: 30px">DB ID</th>
+                {% endif %}
+                {% if "genus" in table_columns %}
+                    <th>Genus</th>
+                {% endif %}
+                {% if "species" in table_columns %}
+                    <th>Species</th>
+                {% endif %}
+                {% if "common_name" in table_columns %}
+                    <th>Common Name</th>
+                {% endif %}
+                {% if "observation_date" in table_columns %}
+                    <th>Observation date</th>
+                {% endif %}
+                {% if "observer" in table_columns %}
                     <th>Observer</th>
                 {% endif %}
-                <th>Site description</th>
-                {% if not filters.reservation %}
+                {% if "site_description" in table_columns %}
+                    <th>Site description</th>
+                {% endif %}
+                {% if "reservation" in table_columns %}
                     <th>Reservation</th>
                 {% endif %}
-                {% if not filters.watershed %}
+                {% if "watershed" in table_columns %}
                     <th>Watershed</th>
                 {% endif %}
-                {% if not filters.state_status %}
+                {% if "state_status" in table_columns %}
                     <th>State Status</th>
                 {% endif %}
-                {% if not filters.federal_status %}
+                {% if "federal_status" in table_columns %}
                     <th>Federal Status</th>
                 {% endif %}
-                {% if not filters.global_status %}
+                {% if "global_status" in table_columns %}
                     <th>Global Status</th>
                 {% endif %}
-                {% if not filters.cm_status %}
+                {% if "cm_status" in table_columns %}
                     <th>CM Status</th>
                 {% endif %}
-                <th style="width: 70px">Latitude</th>
-                <th style="width: 70px">Longitude</th>
+                {% if "latitude" in table_columns %}
+                    <th style="width: 70px">Latitude</th>
+                {% endif %}
+                {% if "longitude" in table_columns %}
+                    <th style="width: 70px">Longitude</th>
+                {% endif %}
             </tr>
             {% for occurrence in occurrences %}
             <tr>
-                <td>{{ occurrence.index}}</td>
-                <td>{{ occurrence.id }}</td>
-                <td>{{ occurrence.genus|default_if_none:"-" }}</td>
-                <td>{{ occurrence.species|default_if_none:"-" }}</td>
-                <td>{{ occurrence.common_name|default_if_none:"-" }}</td>
-                <td>{{ occurrence.observation_date|default_if_none:"-" }}</td>
-                {% if not filters.observer %}
+                {% if "list_id" in table_columns %}
+                    <td>{{ occurrence.index}}</td>
+                {% endif %}
+                {% if "db_id" in table_columns %}
+                    <td>{{ occurrence.id }}</td>
+                {% endif %}
+                {% if "genus" in table_columns %}
+                    <td>{{ occurrence.genus|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "species" in table_columns %}
+                    <td>{{ occurrence.species|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "common_name" in table_columns %}
+                    <td>{{ occurrence.common_name|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "observation_date" in table_columns %}
+                    <td>{{ occurrence.observation_date|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "observer" in table_columns %}
                     <td>{{ occurrence.observer|default_if_none:"-" }}</td>
                 {% endif %}
-                <td>{{ occurrence.site_description|default_if_none:"-" }}</td>
-                {% if not filters.reservation %}
+                {% if "site_description" in table_columns %}
+                    <td>{{ occurrence.site_description|default_if_none:"-" }}</td>
+                {% endif %}
+                {% if "reservation" in table_columns %}
                     <td>{{ occurrence.reservation|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.watershed %}
+                {% if "watershed" in table_columns %}
                     <td>{{ occurrence.watershed|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.state_status %}
+                {% if "state_status" in table_columns %}
                     <td>{{ occurrence.state_status|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.federal_status %}
+                {% if "federal_status" in table_columns %}
                     <td>{{ occurrence.federal_status|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.global_status %}
+                {% if "global_status" in table_columns %}
                     <td>{{ occurrence.global_status|default_if_none:"-" }}</td>
                 {% endif %}
-                {% if not filters.cm_status %}
+                {% if "cm_status" in table_columns %}
                     <td>{{ occurrence.cm_status|default_if_none:"-" }}</td>
                 {% endif %}
-                <td>{{ occurrence.latitude|default_if_none:"-"|floatformat:"3" }}</td>
-                <td>{{ occurrence.longitude|default_if_none:"-"|floatformat:"3" }}</td>
+                {% if "latitude" in table_columns %}
+                    <td>{{ occurrence.latitude|default_if_none:"-"|floatformat:"3" }}</td>
+                {% endif %}
+                {% if "longitude" in table_columns %}
+                    <td>{{ occurrence.longitude|default_if_none:"-"|floatformat:"3" }}</td>
+                {% endif %}
             </tr>
             {% endfor %}
         </table>


### PR DESCRIPTION
This PR is connected to #234 

It adds the missing query parameters that enable toggling the table columns in the PDF reports.
Extra query parameters added:

- Parameters that apply to both `/nfdapi/report_taxon` and `/nfdapi/report_natural_area` endpoints:
  - `show_list_id`
  - `show_db_id`
  - `show_observation_date`
  - `show_observer`
  - `show_site_description`
  - `show_reservation`
  - `show_watershed`
  - `show_state_status`
  - `show_federal_status`
  - `show_global_status`
  - `show_cm_status`
  - `show_latitude`
  - `show_longitude`

- Parameters that apply only to the `/nfdapi/report_taxon` endpoint:
  - `show_genus`
  - `show_species`
  - `show_common_name`

- Parameters that apply only to the `/nfdapi/report_natural_area` endpoint:
  - `show_natural_area_code`
  - `show_general_description`

This PR implements a minimum default for the table columns, which means that all of these parameters are all optional.

Each parameter expects a value. The value will be interpreted as `True` if it is of the form `true` (any combination of caps is acceptable, e.g. `TRUE`, `True`, etc.) or `1`. Otherwise it will be interpreted as `False`.
