### PR TITLE
pdf renderer builds taxon common name in a more robust way

### DIFF
--- a/nfdapi/nfdcore/serializers.py
+++ b/nfdapi/nfdcore/serializers.py
@@ -2397,7 +2397,19 @@ class OccurrenceTaxonReportSerializer(BaseOccurrenceReportSerializer):
         return obj.taxon.upper_ranks.get("species", {}).get("name")
 
     def get_common_names(self, obj):
-        return obj.taxon.upper_ranks.get("species", {}).get("common_names", {})
+        sorted_ranks = sorted(
+            obj.taxon.upper_ranks.values(),
+            key=lambda rank_info:rank_info["index"],
+            reverse=True
+        )
+        for rank in sorted_ranks:
+            common_names = rank.get("common_names")
+            if common_names:
+                result = common_names
+                break
+        else:
+            result = {}
+        return result
 
     def get_global_status(self, obj):
         serializer = GenericDictTableSerializer(


### PR DESCRIPTION
This PR fixes an issue with the pdf renderer in the reports endpoints.

The issue was that registered occurrences with a taxon where there was no common name for the species rank were not being handled correctly.

The proposed solution implements a more robust way of generating the common name of an occurrence:

- common names for the various ranks are sorted in hierarchical order and we extract the lowest possible set of names, _i.e._ the most specific ones
- common names are then filtered in order to keep only the english-related names
- finally they are combined into a single string and used for rendering the pdf

Also included in this PR is a safeguard for the possibility of a user turning off all columns in the pdf table. In this case we forcibly add a single column.