### PR TITLE
added `category` query parameter to report API endpoint

### DIFF
--- a/nfdapi/nfdcore/filters.py
+++ b/nfdapi/nfdcore/filters.py
@@ -80,14 +80,14 @@ class CharInFilter(django_filters.BaseInFilter, django_filters.CharFilter):
 class ReportTaxonFilterBackend(BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, view):
+        category = request.query_params.get("category").lower()
+        result = queryset.filter(occurrence_cat__main_cat__iexact=category)
         rank_name = request.query_params.get("rank_name", "species").lower()
         rank_value = request.query_params.get("rank_value")
         if rank_value:
             lookup = "taxon__upper_ranks__{}__name__icontains".format(
                 rank_name)
-            result = queryset.filter(**{lookup: rank_value})
-        else:
-            result = queryset
+            result = result.filter(**{lookup: rank_value})
         return result
 
 

--- a/nfdapi/nfdrenderers/pdf.py
+++ b/nfdapi/nfdrenderers/pdf.py
@@ -254,7 +254,8 @@ class OccurrenceTaxonReportRenderer(BaseOccurrenceReportRenderer):
         rank_value = query_params.get("rank_value")
         filters = self.get_filters(query_params)
         filters.update(
-            feature=" ".join((rank_name, rank_value)) if rank_value else None,
+            category=query_params.get("category"),
+            rank=" ".join((rank_name, rank_value)) if rank_value else None,
             county=query_params.get("county"),
             quad=_get_quad(query_params),
         )

--- a/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
+++ b/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
@@ -29,7 +29,7 @@
     <p>
         <strong>Filters</strong><br>
         <ul>
-            <li>Feature: <strong>{{ filters.category }}</strong></li>
+            <li>Feature type: <strong>{{ filters.category }}</strong></li>
             {% if filters.rank %}
             <li>Rank: <strong>{{ filters.rank }}</strong></li>
             {% endif %}

--- a/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
+++ b/nfdapi/nfdrenderers/templates/nfdrenderers/pdf/taxon_occurrence_report.html
@@ -29,8 +29,9 @@
     <p>
         <strong>Filters</strong><br>
         <ul>
-            {% if filters.feature %}
-                <li>Feature: <strong>{{ filters.feature }}</strong></li>
+            <li>Feature: <strong>{{ filters.category }}</strong></li>
+            {% if filters.rank %}
+            <li>Rank: <strong>{{ filters.rank }}</strong></li>
             {% endif %}
             {% if filters.reservation %}
                 <li>Reservation: <strong>{{ filters.reservation }}</strong></li>


### PR DESCRIPTION
This PR adds a mandatory `category` query parameter to the `/nfdapi/report_taxon` API endpoint. This is in addition to the parameters already available (see #238).

Example request:
```
http://10.0.1.131:8000/nfdapi/report_taxon/?
    show_list_id=true&
    show_db_id=true&
    show_genus=true&
    show_species=true&
    show_common_name=true&
    show_natural_area_code=true&
    show_general_description=true&
    show_observation_date=true&
    show_observer=true&
    show_site_description=true&
    show_reservation=true&
    show_watershed=true&
    show_global_status=true&
    show_federal_status=true&
    show_state_status=true&
    show_cm_status=true&
    show_latitude=true&
    show_longitude=true&
    rank_name=genus&
    rank_value=canis&
    category=animal&
    format=pdf
```

fixes #250