### PR TITLE
superuser allowed to perform write operations

### DIFF
--- a/nfdapi/nfdcore/jwtutils.py
+++ b/nfdapi/nfdcore/jwtutils.py
@@ -1,20 +1,27 @@
 
 
 def jwt_response_payload_handler(token, user=None, request=None):
-    return {
-        'token': token,
-        'user': {
-            'name': user.username,
-            'is_staff': user.is_staff,
-            'plant_writer': user.is_plant_writer,
-            'plant_publisher': user.is_plant_publisher,
-            'animal_writer': user.is_animal_writer,
-            'animal_publisher': user.is_animal_publisher,
-            'slimemold_writer': user.is_slimemold_writer,
-            'slimemold_publisher': user.is_slimemold_publisher,
-            'fungus_writer': user.is_fungus_writer,
-            'fungus_publisher': user.is_fungus_publisher,
-            'naturalarea_writer': user.is_naturalarea_writer,
-            'naturalarea_publisher': user.is_naturalarea_publisher
-            }
+    result = {
+        "token": token,
+        "user": {
+            "name": user.username,
+            "is_staff": user.is_staff,
+        },
     }
+    feature_types = [
+        "animal",
+        "fungus",
+        "naturalarea",
+        "plant",
+        "slimemold",
+    ]
+    for feature_type in feature_types:
+        for role in ["writer", "publisher"]:
+            permission_name = "{}_{}".format(feature_type, role)
+            if user.is_superuser:
+                permission_value = True
+            else:
+                permission_value = getattr(
+                    user, "is_{}".format(permission_name), False)
+            result["user"][permission_name] = permission_value
+    return result

--- a/nfdapi/nfdcore/permissions.py
+++ b/nfdapi/nfdcore/permissions.py
@@ -2,34 +2,22 @@ from rest_framework import permissions
 from rest_framework.status import HTTP_401_UNAUTHORIZED
 from rest_framework.permissions import SAFE_METHODS
 
+
 def get_permissions(user, featuretype_name):
     """
     Gets the permissions for the provided user and feature type.
     Returns a tuple (can_write, can_publish)
     """
+    if user.is_superuser:
+        result = (True, True)
+    else:
+        is_writer = getattr(
+            user, "is_{}_writer".format(featuretype_name), False)
+        is_publisher = getattr(
+            user, "is_{}_publisher".format(featuretype_name), False)
+        result = (is_writer, is_publisher)
+    return result
 
-    return {
-        "animal": (user.is_animal_writer, user.is_animal_publisher),
-        "slimemold": (user.is_slimemold_writer, user.is_slimemold_publisher),
-        "plant": (user.is_plant_writer, user.is_plant_publisher),
-        "fungus": (user.is_fungus_writer, user.is_fungus_publisher),
-        "naturalarea": (
-            user.is_naturalarea_writer, user.is_naturalarea_publisher),
-    }.get(featuretype_name, (False, False))
-
-
-def can_create_feature_type(user, featuretype_name):
-    if featuretype_name[0]=="a":
-        return user.is_animal_writer
-    if featuretype_name[0]=="s":
-        return user.is_slimemold_writer
-    if featuretype_name[0]=="p":
-        return user.is_plant_writer
-    if featuretype_name[0]=="f":
-        return user.is_fungus_writer
-    if featuretype_name[0]=="n":
-        return user.is_naturalarea_writer
-    return False
 
 def can_publish_feature_type(user, featuretype_name):
     if featuretype_name[0]=="a":
@@ -44,78 +32,84 @@ def can_publish_feature_type(user, featuretype_name):
         return user.is_naturalarea_publisher
     return False
 
+
 def can_update_feature_type(user, featuretype_name):
-    if featuretype_name[0]=="a":
-        return user.is_animal_publisher or user.is_animal_writer
-    if featuretype_name[0]=="s":
-        return user.is_slimemold_publisher or user.is_slimemold_writer
-    if featuretype_name[0]=="p":
-        return user.is_plant_publisher or user.is_plant_writer
-    if featuretype_name[0]=="f":
-        return user.is_fungus_publisher or user.is_fungus_writer
-    if featuretype_name[0]=="n":
-        return user.is_naturalarea_publisher or user.is_naturalarea_writer
-    return False
+    is_publisher = getattr(user, "is_{}_publisher".format(
+        featuretype_name), False)
+    return is_publisher or getattr(
+        user, "is_{}_writer".format(featuretype_name), False)
+
 
 class CanWriteOrUpdateAny(permissions.BasePermission):
+
     def has_permission(self, request, view):
-        return (request.user.is_animal_publisher or \
-                request.user.is_animal_writer or \
-                request.user.is_slimemold_publisher or \
-                request.user.is_slimemold_writer or \
-                request.user.is_plant_publisher or \
-                request.user.is_plant_writer or \
-                request.user.is_fungus_publisher or \
-                request.user.is_fungus_writer or \
-                request.user.is_naturalarea_publisher or \
-                request.user.is_naturalarea_writer)
+        user = request.user
+        if user.is_superuser:
+            return True
+        else:
+            return (
+                request.user.is_animal_publisher or
+                request.user.is_animal_writer or
+                request.user.is_slimemold_publisher or
+                request.user.is_slimemold_writer or
+                request.user.is_plant_publisher or
+                request.user.is_plant_writer or
+                request.user.is_fungus_publisher or
+                request.user.is_fungus_writer or
+                request.user.is_naturalarea_publisher or
+                request.user.is_naturalarea_writer
+            )
+
     def has_object_permission(self, request, view, obj):
         return True
+
     
 class CanUpdateFeatureType(permissions.BasePermission):
+
     def has_permission(self, request, view):
-        if request.method not in SAFE_METHODS:
+        user = request.user
+        if request.method not in SAFE_METHODS and not user.is_superuser:
             return can_update_feature_type(request.user, view.args[0])
         return True
     
     def has_object_permission(self, request, view, obj):
         return True
 
+
 class CanCreateFeatureType(permissions.BasePermission):
+    FEATURETYPE_NAME = ""
+
     def has_permission(self, request, view):
-        if request.method=='POST':
-            return can_create_feature_type(request.user, view.args[0])
-        return True
+        result = True
+        user = request.user
+        if request.method == 'POST' and not user.is_superuser:
+            feature_type_name = view.args[0]
+            result = getattr(
+                user,
+                "is_{}_writer".format(self.FEATURETYPE_NAME),
+                False
+            )
+        return result
     
     def has_object_permission(self, request, view, obj):
         return True
 
-class CanCreateAnimals(permissions.BasePermission):
-    def has_permission(self, request, view):
-        if request.method=='POST':
-            return request.user.is_animal_writer
-        return True
-    
-class CanCreatePlants(permissions.BasePermission):
-    def has_permission(self, request, view):
-        if request.method=='POST':
-            return request.user.is_plant_writer
-        return True
 
-class CanCreateFungus(permissions.BasePermission):
-    def has_permission(self, request, view):
-        if request.method=='POST':
-            return request.user.is_fungus_writer
-        return True
+class CanCreateAnimals(CanCreateFeatureType):
+    FEATURETYPE_NAME = "animal"
 
-class CanCreateSlimeMold(permissions.BasePermission):
-    def has_permission(self, request, view):
-        if request.method=='POST':
-            return request.user.is_slimemold_writer
-        return True
 
-class CanCreateNaturalAreas(permissions.BasePermission):
-    def has_permission(self, request, view):
-        if request.method=='POST':
-            return request.user.is_naturalarea_writer
-        return True
+class CanCreatePlants(CanCreateFeatureType):
+    FEATURETYPE_NAME = "plant"
+
+
+class CanCreateFungus(CanCreateFeatureType):
+    FEATURETYPE_NAME = "fungus"
+
+
+class CanCreateSlimeMold(CanCreateFeatureType):
+    FEATURETYPE_NAME = "slimemold"
+
+
+class CanCreateNaturalAreas(CanCreateFeatureType):
+    FEATURETYPE_NAME = "naturalarea"


### PR DESCRIPTION
This PR enhances the existing permissions checks in order to allow a django superuser to perform all actions without being explicitly granted each individual perm.

Since we are storing individual permissions as attributes on the user model (and not as standard django permissions) it was necessary to add explicit checks for the user's `is_superuser` field in the functions/classes that implement permissions.

With this PR, the frontend application is also able to generate a suitable GUI for the admin user, allowing it to create/modify records. The relevant change is in the `nfdcore.jwtutils.jwt_response_payload_handler`.