### PR TITLE
made AUTH_LDAP_GROUP_TYPE configurable by means of an environment variable

### DIFF
--- a/nfdapi/nfdapi/settings.py
+++ b/nfdapi/nfdapi/settings.py
@@ -222,7 +222,13 @@ AUTH_LDAP_GROUP_SEARCH = ldap_config.LDAPSearch(
     get_environment_variable("LDAP_GROUP_SEARCH_DN"),
     ldap.SCOPE_SUBTREE
 )
-AUTH_LDAP_GROUP_TYPE = ldap_config.NestedGroupOfNamesType()
+AUTH_LDAP_GROUP_TYPE = getattr(
+    ldap_config,
+    get_environment_variable(
+        "LDAP_GROUP_TYPE",
+        default_value="NestedGroupOfNamesType"
+    )
+)()
 
 AUTH_LDAP_FIND_GROUP_PERMS = True
 AUTH_LDAP_CACHE_GROUPS = True


### PR DESCRIPTION
This PR implements a way to define the `AUTH_LDAP_GROUP_TYPE` setting by means of settings the `LDAP_GROUP_TYPE` environment variable. This change is introduced in order to cope with differences between test and prod environments. The default value is the one used the production environment