### PR TITLE
fix featuretype saving bug due to faulty and unneeded statement

### DIFF
--- a/nfdapi/nfdcore/permissions.py
+++ b/nfdapi/nfdcore/permissions.py
@@ -83,7 +83,6 @@ class CanCreateFeatureType(permissions.BasePermission):
         result = True
         user = request.user
         if request.method == 'POST' and not user.is_superuser:
-            feature_type_name = view.args[0]
             result = getattr(
                 user,
                 "is_{}_writer".format(self.FEATURETYPE_NAME),


### PR DESCRIPTION
This PR fixes a bug in the featuretype saving workflow.

It is a small bugfix that only removes an unneeded, and also illegal, statement.