### PR TITLE
some taxon conservation fields now show as regular strings in the UI

### DIFF
--- a/nfdapi/nfdcore/form_definitions/common-pages.yml
+++ b/nfdapi/nfdcore/form_definitions/common-pages.yml
@@ -339,27 +339,23 @@ taxon_status:
   fields:
     - label: CM Status
       field: taxon.cm_status
-      widget: stringcombo
       choices: nfdcore.models.CmStatus
       readonly: true
     - label: S Rank
       field: taxon.s_rank
-      widget: stringcombo
       choices: nfdcore.models.SRank
       readonly: true
-      show_key_with_value: true
+      widget: textarea
     - label: N Rank
       field: taxon.n_rank
-      widget: stringcombo
       choices: nfdcore.models.NRank
       readonly: true
-      show_key_with_value: true
+      widget: textarea
     - label: G Rank
       field: taxon.g_rank
-      widget: stringcombo
       choices: nfdcore.models.GRank
       readonly: true
-      show_key_with_value: true
+      widget: textarea
     - label: Native
       field: taxon.native
       widget: boolean


### PR DESCRIPTION
This PR makes taxon conservation fields show as regular strings in the UI. Affected fields:

- `cm_status`
- `s_rank`
- `n_rank`
- `g_rank`

Contrary to the issue description, the FK relationship was kept, allowing the app admins to edit a taxon's conservation fields by using the django admin, as depicted in the following video:

![nfd_edit_taxon_conservation_ranks](https://user-images.githubusercontent.com/732010/51261046-73877200-19a7-11e9-9a68-96f802e8b8e8.gif)


fixes #270