### PR TITLE
explictly set file upload file permissions

### DIFF
--- a/nfdapi/nfdapi/settings.py
+++ b/nfdapi/nfdapi/settings.py
@@ -331,6 +331,9 @@ USE_L10N = True
 
 USE_TZ = True
 
+FILE_UPLOAD_PERMISSIONS = 0644  # python2 octal number - This would be different on python3
+
+
 # LOGGING = {
 #     'version': 1,
 #     'disable_existing_loggers': False,

--- a/nfdapi/nfdapi/urls.py
+++ b/nfdapi/nfdapi/urls.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.conf.urls import include
+from django.conf.urls.static import static
 from django.conf.urls import url
 from django.contrib import admin
 from rest_framework_jwt.views import obtain_jwt_token
@@ -90,4 +92,4 @@ urlpatterns = [
     # url(r'^'+APP_NAME+r'species/$', views.SpeciesSearch.as_view()),
     # url(r'^'+APP_NAME+r'species/(?P<pk>[0-9]+)/$', views.SpeciesDetail.as_view()),
     url(r'^'+APP_NAME, include(router.urls)),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This PR explicitly sets the file permissions for files uploaded through the django app in order to get a consistent behavior between deployments. The proposed changes do not limit the size of uploaded files

Fixes #268 