### PR TITLE
implement server-side validation of uploaded photos

### DIFF
--- a/nfdapi/nfdapi/settings.py
+++ b/nfdapi/nfdapi/settings.py
@@ -333,6 +333,8 @@ USE_TZ = True
 
 FILE_UPLOAD_PERMISSIONS = 0644  # python2 octal number - This would be different on python3
 
+NFDCORE_MAX_UPLOAD_SIZE_MEGABYTES = 50
+
 
 # LOGGING = {
 #     'version': 1,


### PR DESCRIPTION
This PR implements server-side validation of user-uploaded photographs' sizes. Maximum size is configurable in the `settings.NFDCORE_MAX_UPLOAD_SIZE_MEGABYTES` variable and is currently set to 50 MB.

Fixes #281 